### PR TITLE
fix: ajusto height y object-fit para evitar recorte de imagenes en el…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ## [Release Actividad Obligatoria N°2] - 2026-04-19
 
 ### Fixed
+- [fix/hero-images-object-fit]  ajusto height y object-fit para evitar recorte de imagenes
+  PR: [#71](https://github.com/GonzaloBarbano/E-commerce/pull/71) - @Naguirre0102 (Coordinador / DevOps)
+
 - [fix/tabla-overflow-mobile]  agrego contenedor con overflow auto para evitar desbordamiento de la tabla en mobile
   PR: [#70](https://github.com/GonzaloBarbano/E-commerce/pull/70) - @Naguirre0102 (Coordinador / DevOps)
 

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -45,7 +45,7 @@
   .featured-gallery img,
   .hero-gallery img,
   .hero-images img {
-    max-height: 200px;
+    height: 180px;
   }
 
   .featured-gallery,

--- a/css/styles.css
+++ b/css/styles.css
@@ -138,8 +138,9 @@ h3 {
 .hero-gallery img,
 .hero-images img {
   width: 100%;
-  max-height: 400px;
-  object-fit: cover;
+  height: 280px;
+  object-fit: contain;
+  background-color: var(--color-bg);
   border-radius: var(--border-radius-sm);
 }
 


### PR DESCRIPTION
## 🛠️ Resolución de Bug Visual (RC-V4)

Esta PR soluciona el bloqueante **RC-V4**, donde las imágenes principales de la sección Hero se veían recortadas, afectando la presentación de los productos.

### 📝 Cambios realizados:
- Se reemplazó el `max-height` por un `height: 280px` explícito en las imágenes del Hero.
- Se agregó la propiedad `object-fit: contain;` para garantizar que la imagen completa se adapte al contenedor sin perder su relación de aspecto.
- Se agregó `display: block;` para eliminar espacios en blanco residuales.