### PR TITLE
Alineo breakpoint del responsive.css con Bootstrap lg=992px (closes #86)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,17 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ---
 
-## [Unreleased]
+## [Recuperatorio Parcial 1] - 2026-05-05
 
 ### Added
 
 - [feature/coord-devops-update-figma-and-readme] Actualizo readme y mockup
   PR: [#82](https://github.com/GonzaloBarbano/E-commerce/pull/82) - @GonzaloBarbano (Coordinador / DevOps)
+
+### Fixed
+
+- [fix/align-breakpoint-sidebar-bootstrap] Alineo breakpoint del responsive.css con Bootstrap lg=992px — resuelve espacio vacío a la izquierda del main-content entre 992-1023px (closes #86)
+  PR: [#PENDIENTE](https://github.com/GonzaloBarbano/E-commerce/pulls) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
 
 ## [Release Actividad Obligatoria N°2] - 2026-04-19
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 
 - [fix/align-breakpoint-sidebar-bootstrap] Alineo breakpoint del responsive.css con Bootstrap lg=992px — resuelve espacio vacío a la izquierda del main-content entre 992-1023px (closes #86)
-  PR: [#PENDIENTE](https://github.com/GonzaloBarbano/E-commerce/pulls) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
+  PR: [#90](https://github.com/GonzaloBarbano/E-commerce/pull/90) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
 
 ## [Release Actividad Obligatoria N°2] - 2026-04-19
 

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -8,8 +8,9 @@ html {
   max-width: 100%;
 }
 
-/* TABLET */
-@media screen and (max-width: 1024px) {
+/* TABLET — alineado con breakpoint lg de Bootstrap (≥992px) para evitar
+   espacio vacío a la izquierda del main-content entre 992-1023px (BUG-006) */
+@media screen and (max-width: 991.98px) {
   :root {
     --sidebar-width: 0px;
   }


### PR DESCRIPTION
## Resumen
Cambia el media query de `responsive.css` de `max-width: 1024px` a `max-width: 991.98px` para alinearlo con el breakpoint `lg` de Bootstrap 5 (≥992px). Resuelve el espacio vacío a la izquierda del main-content que aparecía entre 992 y 1023px de ancho.

## Issue cerrado
Closes #86

## Detalles del cambio
- **`css/responsive.css`**: 1 línea modificada, comentario agregado explicando el motivo del breakpoint.
- **`changelog.md`**: entrada en `[Unreleased] > [Fixed]`.

## Por qué NO se elimina la regla `.sidebar { display: none }`
Aunque el issue sugiere eliminarla por redundancia con `d-none d-lg-block`, esa clase de Bootstrap aún no está mergeada en `develop` (vive en `feature/dev-frontend-bootstrap-update-migration`). Eliminar la regla ahora dejaría el sidebar visible en mobile/tablet hasta que se mergee el feature → regresión visible. La limpieza completa la hace una iteración futura.

## Test plan
- [x] Verificar que el cambio no introduce overflow horizontal en mobile.
- [x] Verificar que el sidebar sigue oculto en viewports `<992px`.
- [ ] Re-ejecutar el análisis del Test Case 6 una vez mergeado feature, para confirmar que el bug se cierra completamente.

## Rama
`fix/align-breakpoint-sidebar-bootstrap` → `develop`

## Rol
Desarrollador Frontend/Bootstrap — @Naguirre0102
