### PR TITLE
[fix] Cierro div.table-wrapper faltante en specs-table (closes #87)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 - [feature/coord-devops-update-figma-and-readme] Actualizo readme y mockup
   PR: [#82](https://github.com/GonzaloBarbano/E-commerce/pull/82) - @GonzaloBarbano (Coordinador / DevOps)
 
+### Fixed
+
+- [fix/close-table-wrapper-specs-table] Cierro &lt;div class="table-wrapper"&gt; faltante en la specs-table de la sección Compatibilidad — resuelve HTML inválido detectado en el TC6 (closes #87)
+  PR: [#PENDIENTE](https://github.com/GonzaloBarbano/E-commerce/pulls) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
+
 ## [Release Actividad Obligatoria N°2] - 2026-04-19
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 - [fix/close-table-wrapper-specs-table] Cierro &lt;div class="table-wrapper"&gt; faltante en la specs-table de la sección Compatibilidad — resuelve HTML inválido detectado en el TC6 (closes #87)
   PR: [#91](https://github.com/GonzaloBarbano/E-commerce/pull/91) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
 
+- [fix/align-breakpoint-sidebar-bootstrap] Alineo breakpoint del responsive.css con Bootstrap lg=992px — resuelve espacio vacío a la izquierda del main-content entre 992-1023px (closes #86)
+  PR: [#90](https://github.com/GonzaloBarbano/E-commerce/pull/90) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
+
 ## [Release Actividad Obligatoria N°2] - 2026-04-19
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 
 - [fix/close-table-wrapper-specs-table] Cierro &lt;div class="table-wrapper"&gt; faltante en la specs-table de la sección Compatibilidad — resuelve HTML inválido detectado en el TC6 (closes #87)
-  PR: [#PENDIENTE](https://github.com/GonzaloBarbano/E-commerce/pulls) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
+  PR: [#91](https://github.com/GonzaloBarbano/E-commerce/pull/91) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
 
 ## [Release Actividad Obligatoria N°2] - 2026-04-19
 

--- a/index.html
+++ b/index.html
@@ -686,20 +686,21 @@
                 <article class="guide-card">
                   <h3>Fuente de Alimentación</h3>
                   <div class="table-wrapper">
-                  <table class="specs-table">
-                    <thead>
-                      <tr>
-                        <th scope="col">GPU</th>
-                        <th scope="col">Fuente Recomendada</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td>RTX 4090</td>
-                        <td>1000W+</td>
-                      </tr>
-                    </tbody>
-                  </table>
+                    <table class="specs-table">
+                      <thead>
+                        <tr>
+                          <th scope="col">GPU</th>
+                          <th scope="col">Fuente Recomendada</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>RTX 4090</td>
+                          <td>1000W+</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
                 </article>
               </div>
             </div>


### PR DESCRIPTION
## Resumen
Agrega el `</div>` faltante que cierra `<div class="table-wrapper">` envolviendo a `<table class="specs-table">` en la sección "Guías de Compatibilidad". El cierre estaba ausente y `<article>` cerraba antes que el wrapper, generando HTML estructuralmente inválido.

## Issue cerrado
Closes #87

## Detalles del cambio
- **`index.html`** (sección `#compatibilidad`):
  - Agregado `</div>` antes de `</article>` para cerrar correctamente `<div class="table-wrapper">`.
  - Ajustada la indentación de `<table>`, `<thead>`, `<tbody>` un nivel más adentro para reflejar la jerarquía real (cosmético, mismo árbol DOM).
- **`changelog.md`**: entrada en `[Unreleased] > [Fixed]`.

## Aclaración
Bug **preexistente** — no fue introducido por la migración a Bootstrap del Primer Parcial. Fue detectado por el análisis estático del Test Case 6 ([`docs/04-testing/test-case-6.md`](docs/04-testing/test-case-6.md)), que identifica este tipo de hallazgos para que el rol Frontend/Bootstrap los resuelva con `fix/*` (consigna PDF, sección 3.1.2 punto 8).

## Test plan
- [x] El HTML pasa validación estructural local (apertura/cierre balanceados).
- [x] Visualmente la sección "Guías de Compatibilidad" se ve igual que antes.
- [ ] Verificación con https://validator.w3.org/ después del merge a develop.

## Rama
`fix/close-table-wrapper-specs-table` → `develop`

## Rol
Desarrollador Frontend/Bootstrap — @Naguirre0102
