### PR TITLE
[feature] Migración a Bootstrap 5.3 — Frontend/Bootstrap (closes #83)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Added
 
+- [feature/dev-frontend-bootstrap-update-migration] Migración del layout a sistema de grilla Bootstrap 5.3 (CDN + bootstrap-overrides.css + sistema de columnas + tablas con .table-responsive) + test-case-6.md con análisis estático en iPhone 14 Pro, Galaxy S23 e iPad Air (closes #83)
+  PR: [#93](https://github.com/GonzaloBarbano/E-commerce/pull/93) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
+
 - [feature/coord-devops-update-figma-and-readme] Actualizo readme y mockup
   PR: [#82](https://github.com/GonzaloBarbano/E-commerce/pull/82) - @GonzaloBarbano (Coordinador / DevOps)
 

--- a/css/bootstrap-overrides.css
+++ b/css/bootstrap-overrides.css
@@ -6,9 +6,11 @@
    ============================================ */
 
 :root {
-  /* Color tokens — mapeo a la paleta del mockup */
+  /* Color tokens — mapeo a la paleta del mockup.
+     --bs-primary-rgb usa la versión RGB del token expuesta en styles.css,
+     así si --color-primary cambia en el futuro, los rgba() también lo siguen. */
   --bs-primary: var(--color-primary);
-  --bs-primary-rgb: 124, 58, 237;
+  --bs-primary-rgb: var(--color-primary-rgb);
   --bs-body-color: var(--color-text);
   --bs-body-bg: var(--color-bg);
   --bs-border-color: var(--color-border);
@@ -56,12 +58,12 @@
 .form-control:focus,
 .form-select:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 0.2rem rgba(124, 58, 237, 0.2);
+  box-shadow: 0 0 0 0.2rem rgba(var(--color-primary-rgb), 0.2);
 }
 
 .form-check-input:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 0.2rem rgba(124, 58, 237, 0.2);
+  box-shadow: 0 0 0 0.2rem rgba(var(--color-primary-rgb), 0.2);
 }
 
 .form-check-input:checked {

--- a/css/bootstrap-overrides.css
+++ b/css/bootstrap-overrides.css
@@ -1,0 +1,82 @@
+/* ============================================
+   PC-HARDWARE E-COMMERCE | BOOTSTRAP OVERRIDES
+   Mapea variables --bs-* a los tokens del proyecto
+   definidos en styles.css (:root) para mantener
+   la identidad visual del e-commerce sobre Bootstrap 5.3.
+   ============================================ */
+
+:root {
+  /* Color tokens — mapeo a la paleta del mockup */
+  --bs-primary: var(--color-primary);
+  --bs-primary-rgb: 124, 58, 237;
+  --bs-body-color: var(--color-text);
+  --bs-body-bg: var(--color-bg);
+  --bs-border-color: var(--color-border);
+  --bs-border-radius: var(--border-radius);
+  --bs-border-radius-sm: var(--border-radius-sm);
+  --bs-secondary-color: var(--color-text-muted);
+  --bs-link-color: var(--color-primary);
+  --bs-link-hover-color: var(--color-primary-hover);
+
+  /* Tipografía — la fuente Inter ya viene de Google Fonts en index.html */
+  --bs-body-font-family: "Inter", sans-serif;
+  --bs-body-font-size: var(--font-size-body);
+}
+
+/* ============================================
+   BUTTONS — alinear .btn-primary de Bootstrap
+   con el botón primario del proyecto
+   ============================================ */
+
+.btn-primary {
+  --bs-btn-bg: var(--color-primary);
+  --bs-btn-border-color: var(--color-primary);
+  --bs-btn-hover-bg: var(--color-primary-hover);
+  --bs-btn-hover-border-color: var(--color-primary-hover);
+  --bs-btn-active-bg: var(--color-primary-hover);
+  --bs-btn-active-border-color: var(--color-primary-hover);
+  --bs-btn-color: #ffffff;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-active-color: #ffffff;
+  font-weight: var(--font-weight-semibold);
+}
+
+.btn-outline-primary {
+  --bs-btn-color: var(--color-primary);
+  --bs-btn-border-color: var(--color-primary);
+  --bs-btn-hover-bg: var(--color-primary);
+  --bs-btn-hover-border-color: var(--color-primary);
+  --bs-btn-active-bg: var(--color-primary-hover);
+}
+
+/* ============================================
+   FORMS — focus y check coherentes con la paleta
+   ============================================ */
+
+.form-control:focus,
+.form-select:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 0.2rem rgba(124, 58, 237, 0.2);
+}
+
+.form-check-input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 0.2rem rgba(124, 58, 237, 0.2);
+}
+
+.form-check-input:checked {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+/* ============================================
+   TABLES — mantener estilo del proyecto
+   sobre la clase .table de Bootstrap
+   ============================================ */
+
+.table {
+  --bs-table-bg: var(--color-surface-card);
+  --bs-table-border-color: var(--color-border);
+  --bs-table-striped-bg: var(--color-bg);
+  margin-bottom: 0;
+}

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -8,13 +8,13 @@ html {
   max-width: 100%;
 }
 
-/* TABLET */
+/* TABLET — la regla `.sidebar { display: none }` se removió por redundancia
+   con la clase utilitaria `d-none d-lg-block` aplicada al <aside> en index.html.
+   Bootstrap es ahora la única fuente de verdad para el ocultamiento del sidebar
+   en mobile/tablet. */
 @media screen and (max-width: 1024px) {
   :root {
     --sidebar-width: 0px;
-  }
-  .sidebar {
-    display: none;
   }
   .main-content {
     margin-left: 0;

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -23,9 +23,6 @@ html {
   .footer {
     margin-left: 0;
   }
-  .featured-gallery {
-    grid-template-columns: repeat(2, 1fr);
-  }
 }
 
 /* MOBILE */
@@ -92,15 +89,6 @@ html {
   .hero-gallery img,
   .hero-images img {
     height: 180px;
-  }
-
-  .featured-gallery {
-    grid-template-columns: 1fr;
-  }
-
-  .products-grid {
-    grid-template-columns: 1fr;
-    gap: var(--spacing-md);
   }
 
   /* RC-FIX: Tabla mobile - garantizar scroll horizontal */

--- a/css/styles.css
+++ b/css/styles.css
@@ -140,17 +140,7 @@ main {
 }
 
 .featured-gallery {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--spacing-md);
   margin: var(--spacing-lg) 0;
-}
-
-.products-grid {
-  display: grid;
-  /* RC-FIX: min() garantiza que nunca supere el ancho disponible en mobile */
-  grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
-  gap: var(--spacing-lg);
 }
 
 .visually-hidden {
@@ -176,9 +166,6 @@ main {
 }
 
 .footer-container {
-  display: flex;
-  gap: var(--spacing-xl);
-  flex-wrap: wrap;
   margin-bottom: var(--spacing-lg);
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -110,29 +110,21 @@ h3 {
   color: var(--color-primary-light);
 }
 
-/* LAYOUT */
-.main-container {
-  display: flex;
+/* LAYOUT — la grilla la provee Bootstrap (.container-fluid > .row > .col-lg-*).
+   Solo conservamos los estilos visuales y el offset del navbar fijo. */
+main {
   padding-top: var(--navbar-height);
   min-height: 100vh;
 }
 
 .sidebar {
-  width: var(--sidebar-width);
   background-color: var(--color-surface-card);
   border-right: 1px solid var(--color-border);
   padding: var(--spacing-lg);
-  position: fixed;
-  top: var(--navbar-height);
-  left: 0;
-  height: calc(100vh - var(--navbar-height));
   overflow-y: auto;
-  z-index: 10;
 }
 
 .main-content {
-  flex: 1;
-  margin-left: var(--sidebar-width);
   padding: var(--spacing-xl);
 }
 
@@ -181,13 +173,6 @@ h3 {
   background-color: var(--color-surface-dark);
   color: #cbd5e1;
   padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-md);
-}
-
-/* Desktop: ajustar para dejar espacio del sidebar fijo */
-@media (min-width: 992px) {
-  .footer {
-    margin-left: var(--sidebar-width);
-  }
 }
 
 .footer-container {

--- a/css/styles.css
+++ b/css/styles.css
@@ -4,6 +4,7 @@
 
 :root {
   --color-primary: #7c3aed;
+  --color-primary-rgb: 124, 58, 237;
   --color-primary-hover: #6d28d9;
   --color-primary-light: #ede9fe;
   --color-surface-dark: #1e1b2e; /* Equivale a rgb(30, 27, 46) */
@@ -139,8 +140,11 @@ main {
   border-radius: var(--border-radius-sm);
 }
 
+/* margin-bottom solo (en lugar de top+bottom) para no interferir con el
+   margin-inline negativo del .row de Bootstrap. El espacio superior lo aporta
+   el margin-bottom natural del <h2> que precede a la galería. */
 .featured-gallery {
-  margin: var(--spacing-lg) 0;
+  margin-bottom: var(--spacing-lg);
 }
 
 .visually-hidden {

--- a/docs/03-specs/primer-parcial/spec-frontend-bootstrap.md
+++ b/docs/03-specs/primer-parcial/spec-frontend-bootstrap.md
@@ -1,0 +1,165 @@
+# Especificación Técnica: Desarrollador Frontend/Bootstrap — Primer Parcial
+
+- **Rol:** Desarrollador Frontend/Bootstrap
+- **Usuario de GitHub:** @Naguirre0102
+- **Rama:** `feature/dev-frontend-bootstrap-update-migration`
+- **Objetivo Principal:** Migrar el layout actual del e-commerce PC-Hardware al sistema de grilla de Bootstrap 5, integrándolo con los estilos existentes (`styles.css`, `components.css`, `responsive.css`) sin romper la identidad visual ni el comportamiento responsive ya validado en la Actividad Obligatoria N°2.
+
+---
+
+## 1. Meta y Contexto
+
+**Qué se va a hacer:**
+Instalar Bootstrap 5.3 vía CDN jsDelivr, crear `css/bootstrap-overrides.css` para mantener la identidad visual del proyecto, y migrar las secciones de layout (sidebar + main, hero, productos y footer) al sistema de columnas (`container` / `row` / `col-*`) de Bootstrap.
+
+**Por qué:**
+La consigna del Primer Parcial exige usar el sistema de columnas de Bootstrap para mejorar la responsividad nativa del sitio en dispositivos móviles, sobre la base ya corregida de la Actividad N°2. La integración debe ser coherente con el mockup actualizado en Figma por el Coordinador (`docs/01-mockup/disenio-bootstrap.png`) y dejar la base lista para que el Especialista en Componentes Bootstrap monte navbar, carousel y modal sin conflictos.
+
+**Limitación de alcance:**
+Este rol **no implementa** los componentes avanzados de Bootstrap (navbar, carousel, modal, etc.) — eso lo cubre el rol de Especialista en Componentes Bootstrap (`feature/esp-com-bootstrap-add-component`).
+
+---
+
+## 2. MOMENTO 1 — ANTES de comenzar (Planificación)
+
+### 2.1 Versión e instalación de Bootstrap
+
+- **Versión:** Bootstrap 5.3.3 (última estable de la línea 5.x al momento del parcial).
+- **Método de instalación:** CDN jsDelivr (sin npm, sin build step), coherente con el flujo estático del proyecto y el deploy en GitHub Pages.
+- **Archivos a incluir en `index.html`:**
+  - CSS de Bootstrap en `<head>`, **antes** de `styles.css` para que los overrides del proyecto tengan mayor especificidad por orden de cascada.
+  - Bundle JS con Popper en cierre de `<body>` (necesario para que el Especialista pueda integrar dropdown, modal, carousel, offcanvas).
+- **Integridad:** se incluirá el atributo `integrity` (SRI) y `crossorigin="anonymous"` en los `<link>` y `<script>` de CDN.
+
+### 2.2 Orden de carga de CSS en `index.html`
+
+```
+1. Google Fonts (Inter)         ← ya existente
+2. Bootstrap 5.3.3 CDN          ← NUEVO
+3. css/styles.css               ← ya existente
+4. css/components.css           ← ya existente
+5. css/bootstrap-overrides.css  ← NUEVO (después de Bootstrap, para sobreescribir variables)
+6. css/responsive.css           ← ya existente (al final, mantiene precedencia en media queries)
+```
+
+### 2.3 Secciones a migrar al sistema de columnas
+
+| Sección actual | Estructura actual | Migración propuesta |
+|---|---|---|
+| `.main-container` | `display: flex` + `.sidebar` con `position: fixed` (250px) + `.main-content` con `margin-left: 250px` | `container-fluid > row > col-lg-3` (sidebar) + `col-lg-9` (main-content). Sidebar pasa a ser parte del flujo en desktop. En `<lg` se oculta con `d-none d-lg-block` (manteniendo el comportamiento actual de la Act. N°2). |
+| `.featured-gallery` (hero) | `display: grid; grid-template-columns: repeat(3, 1fr)` | `row > col-12 col-md-6 col-lg-4` con `g-3` para gap responsive. |
+| `.products-grid` | `display: grid; auto-fill minmax(280px, 1fr)` | `row > col-12 col-sm-6 col-lg-4 g-3 g-md-4` (1/2/3 columnas según breakpoint). |
+| `.footer-container` | `display: flex; flex-wrap: wrap; gap: var(--spacing-xl)` | `container-fluid > row > col-12 col-md-6` para las dos `.footer-section`. |
+| Tablas (`comparison-table`, `specs-table`, `cart-table`) | Wrapper `.table-wrapper` con `overflow-x: auto` | Agregar clases `.table .table-striped .align-middle` + envolver en `.table-responsive` (reemplaza `.table-wrapper` o convive con él). |
+| Inputs y formularios del sidebar | Estilos custom | Aplicar clases utilitarias `.form-control`, `.form-check`, `.form-check-input`, `.btn .btn-primary` / `.btn-outline-secondary` (manteniendo nuestras clases para los overrides de identidad). |
+
+### 2.4 Secciones que NO se migran en este rol
+
+- **Navbar** (`<header class="navbar">`): se mantiene como está. La conversión al componente `<nav class="navbar navbar-expand-lg">` la hace el **Especialista en Componentes Bootstrap** (es uno de los dos componentes avanzados que va a implementar).
+- **Carousel y Modal**: no existen aún; los agrega el Especialista.
+- **Pagination**: el Especialista decidirá si la convierte al componente `<nav>` con `.pagination .page-item .page-link` de Bootstrap.
+
+### 2.5 Estrategia de overrides — `css/bootstrap-overrides.css`
+
+El archivo redefine variables CSS de Bootstrap 5 (que usa custom properties con prefijo `--bs-*`) para alinearlas con el design system del proyecto:
+
+```css
+:root {
+  /* Mapeo de tokens del proyecto a Bootstrap */
+  --bs-primary: var(--color-primary);              /* #7c3aed */
+  --bs-primary-rgb: 124, 58, 237;
+  --bs-body-font-family: "Inter", sans-serif;
+  --bs-body-color: var(--color-text);
+  --bs-body-bg: var(--color-bg);
+  --bs-border-color: var(--color-border);
+  --bs-border-radius: var(--border-radius);
+  --bs-secondary-color: var(--color-text-muted);
+}
+```
+
+Adicionalmente se sobreescriben selectores específicos de Bootstrap (ej. `.btn-primary`, `.form-control:focus`, `.pagination .page-link`) para que el hover/focus respete `--color-primary-hover` y `--color-primary-light`.
+
+### 2.6 Criterios de aceptación (Checklist)
+
+**Documentación previa**
+- [x] `spec-frontend-bootstrap.md` commiteado en `docs/03-specs/primer-parcial/` antes de cualquier cambio de código.
+- [x] Rama `feature/dev-frontend-bootstrap-update-migration` creada y actualizada con `develop` (incluye PR #82 con `disenio-bootstrap.png`).
+
+**Instalación e integración**
+- [ ] Bootstrap 5.3.3 incluido vía CDN jsDelivr (CSS + JS bundle con Popper) con SRI.
+- [ ] Orden de carga de CSS respetado (Bootstrap antes de styles.css; bootstrap-overrides.css después de Bootstrap; responsive.css al final).
+- [ ] `css/bootstrap-overrides.css` creado con mapeo de variables `--bs-*` a los tokens del proyecto.
+- [ ] No se rompe ningún selector existente de `styles.css`, `components.css` ni `responsive.css`.
+
+**Sistema de columnas**
+- [ ] `.main-container` migrado a `container-fluid > row > col-lg-3 + col-lg-9`.
+- [ ] `.featured-gallery` migrado a row + cols responsivos (12/6/4).
+- [ ] `.products-grid` migrado a row + cols responsivos (12/6/4).
+- [ ] `.footer-container` migrado a row + cols (12/6).
+- [ ] Tablas envueltas en `.table-responsive` con clase `.table` aplicada.
+
+**Coherencia visual**
+- [ ] Paleta de colores del mockup mantenida (primary `#7c3aed`, surface-dark `#1e1b2e`).
+- [ ] Tipografía Inter sigue aplicándose globalmente.
+- [ ] Imágenes del hero y productos siguen usando `object-fit: contain` (no se recortan).
+- [ ] Estados hover/focus de botones y links mantienen la transición de 0.3s.
+
+**QA y entregables del rol**
+- [ ] `docs/04-testing/test-case-6.md` documentado siguiendo el template, con prompts y resultados de Playwright MCP en iPhone 14 Pro, Galaxy S23 e iPad Air.
+- [ ] Por cada hallazgo se abre issue tipo `bug` vía GitHub MCP desde Copilot Agent Mode.
+- [ ] Cada issue se resuelve en una rama `fix/<nombre>` → develop, registrada bajo `[Fixed]` en `changelog.md`.
+- [ ] PR `feature/dev-frontend-bootstrap-update-migration` → `develop` creado con la plantilla `.github/PULL_REQUEST_TEMPLATE/feature-template.md`.
+- [ ] Entrada del PR registrada en `changelog.md` con link y descripción del aporte.
+
+---
+
+## 3. MOMENTO 2 — AL CERRAR la tarea (Evidencia)
+
+_(Esta sección se completa al terminar la implementación, antes de abrir la PR.)_
+
+### 3.1 Prompt exacto utilizado con Figma MCP + Copilot Agent Mode
+
+```
+[Pendiente — registrar el prompt usado para que Copilot genere bootstrap-overrides.css y la migración de columnas a partir del mockup disenio-bootstrap.png]
+```
+
+### 3.2 Resultado generado por la IA
+
+_(Pendiente — describir qué archivos generó Copilot, qué clases agregó al index.html y qué estructura de overrides propuso.)_
+
+### 3.3 Ajustes manuales realizados sobre el output
+
+_(Pendiente — listar las correcciones que se hicieron al output de la IA: ajustes de specificity, breakpoints, conflictos con responsive.css, etc.)_
+
+### 3.4 Hallazgos de Playwright MCP e issues abiertas
+
+_(Pendiente — completar al cerrar el test-case-6.md.)_
+
+| Issue # | Dispositivo | Descripción del hallazgo | PR de fix |
+|---|---|---|---|
+|  |  |  |  |
+
+### 3.5 Obstáculos y resoluciones
+
+_(Pendiente — documentar los problemas técnicos que aparezcan durante la migración y cómo se resolvieron.)_
+
+---
+
+## 4. Herramientas y entorno
+
+- **Bootstrap 5.3.3** — CDN jsDelivr.
+- **Figma MCP** — para tomar el mockup actualizado por el Coordinador como contexto en Copilot Agent Mode.
+- **GitHub Copilot Agent Mode** — generación de `bootstrap-overrides.css` y propuesta de migración a columnas.
+- **Playwright MCP (`@playwright/mcp`)** — testing responsive contra `http://localhost:3000`.
+- **GitHub MCP (`@modelcontextprotocol/server-github`)** — apertura de issues bug desde Copilot.
+- **Editor:** Visual Studio Code con configuración de MCPs en `.vscode/mcp.json`.
+- **Control de versiones:** Git + GitHub bajo GitFlow, ramas `feature/`, `fix/`, `release/`.
+
+---
+
+## 5. Referencias del proyecto
+
+- Mockup actualizado a Bootstrap: [`docs/01-mockup/disenio-bootstrap.png`](../../01-mockup/)
+- Spec del Coordinador (contexto): [`spec-devops.md`](./spec-devops.md)
+- Spec del Especialista en Componentes (rol acoplado): [`spec-componentes-bootstrap.md`](./spec-componentes-bootstrap.md) _(pendiente)_
+- Test case responsive a generar: [`docs/04-testing/test-case-6.md`](../../04-testing/) _(pendiente)_

--- a/docs/03-specs/primer-parcial/spec-frontend-bootstrap.md
+++ b/docs/03-specs/primer-parcial/spec-frontend-bootstrap.md
@@ -86,28 +86,28 @@ Adicionalmente se sobreescriben selectores específicos de Bootstrap (ej. `.btn-
 - [x] Rama `feature/dev-frontend-bootstrap-update-migration` creada y actualizada con `develop` (incluye PR #82 con `disenio-bootstrap.png`).
 
 **Instalación e integración**
-- [ ] Bootstrap 5.3.3 incluido vía CDN jsDelivr (CSS + JS bundle con Popper) con SRI.
-- [ ] Orden de carga de CSS respetado (Bootstrap antes de styles.css; bootstrap-overrides.css después de Bootstrap; responsive.css al final).
-- [ ] `css/bootstrap-overrides.css` creado con mapeo de variables `--bs-*` a los tokens del proyecto.
-- [ ] No se rompe ningún selector existente de `styles.css`, `components.css` ni `responsive.css`.
+- [x] Bootstrap 5.3.3 incluido vía CDN jsDelivr (CSS + JS bundle con Popper) con SRI.
+- [x] Orden de carga de CSS respetado (Bootstrap antes de styles.css; bootstrap-overrides.css después de Bootstrap; responsive.css al final).
+- [x] `css/bootstrap-overrides.css` creado con mapeo de variables `--bs-*` a los tokens del proyecto.
+- [x] No se rompe ningún selector existente de `styles.css`, `components.css` ni `responsive.css`.
 
 **Sistema de columnas**
-- [ ] `.main-container` migrado a `container-fluid > row > col-lg-3 + col-lg-9`.
-- [ ] `.featured-gallery` migrado a row + cols responsivos (12/6/4).
-- [ ] `.products-grid` migrado a row + cols responsivos (12/6/4).
-- [ ] `.footer-container` migrado a row + cols (12/6).
-- [ ] Tablas envueltas en `.table-responsive` con clase `.table` aplicada.
+- [x] `.main-container` migrado a `container-fluid > row > col-lg-3 + col-lg-9`.
+- [x] `.featured-gallery` migrado a row + cols responsivos (12/6/4).
+- [x] `.products-grid` migrado a row + cols responsivos (12/6/4).
+- [x] `.footer-container` migrado a row + cols (12/6).
+- [x] Tablas envueltas en `.table-responsive` con clase `.table` aplicada.
 
 **Coherencia visual**
-- [ ] Paleta de colores del mockup mantenida (primary `#7c3aed`, surface-dark `#1e1b2e`).
-- [ ] Tipografía Inter sigue aplicándose globalmente.
-- [ ] Imágenes del hero y productos siguen usando `object-fit: contain` (no se recortan).
-- [ ] Estados hover/focus de botones y links mantienen la transición de 0.3s.
+- [x] Paleta de colores del mockup mantenida (primary `#7c3aed`, surface-dark `#1e1b2e`).
+- [x] Tipografía Inter sigue aplicándose globalmente.
+- [x] Imágenes del hero y productos siguen usando `object-fit: contain` (no se recortan).
+- [x] Estados hover/focus de botones y links mantienen la transición de 0.3s.
 
 **QA y entregables del rol**
-- [ ] `docs/04-testing/test-case-6.md` documentado siguiendo el template, con prompts y resultados de Playwright MCP en iPhone 14 Pro, Galaxy S23 e iPad Air.
-- [ ] Por cada hallazgo se abre issue tipo `bug` vía GitHub MCP desde Copilot Agent Mode.
-- [ ] Cada issue se resuelve en una rama `fix/<nombre>` → develop, registrada bajo `[Fixed]` en `changelog.md`.
+- [x] `docs/04-testing/test-case-6.md` documentado siguiendo el template, con análisis estático en iPhone 14 Pro, Galaxy S23 e iPad Air (ver Nota Metodológica del TC6 sobre por qué no se usó Playwright MCP).
+- [x] Por cada hallazgo se abre issue tipo `bug`: BUG-006 ([#86](https://github.com/GonzaloBarbano/E-commerce/issues/86)) y BUG-007 ([#87](https://github.com/GonzaloBarbano/E-commerce/issues/87)).
+- [x] Cada issue se resuelve en una rama `fix/<nombre>` → develop, registrada bajo `[Fixed]` en `changelog.md`: PR [#90](https://github.com/GonzaloBarbano/E-commerce/pull/90) y PR [#91](https://github.com/GonzaloBarbano/E-commerce/pull/91).
 - [ ] PR `feature/dev-frontend-bootstrap-update-migration` → `develop` creado con la plantilla `.github/PULL_REQUEST_TEMPLATE/feature-template.md`.
 - [ ] Entrada del PR registrada en `changelog.md` con link y descripción del aporte.
 
@@ -115,33 +115,99 @@ Adicionalmente se sobreescriben selectores específicos de Bootstrap (ej. `.btn-
 
 ## 3. MOMENTO 2 — AL CERRAR la tarea (Evidencia)
 
-_(Esta sección se completa al terminar la implementación, antes de abrir la PR.)_
+### 3.1 Prompts utilizados con Copilot Agent Mode
 
-### 3.1 Prompt exacto utilizado con Figma MCP + Copilot Agent Mode
+Se intentaron dos prompts contra Copilot Agent Mode con la intención de invocar el MCP server `playwright` configurado en `.vscode/mcp.json`. El **primer prompt** fue el documentado en la sección "Iteración 1" del [`docs/04-testing/test-case-6.md`](../../04-testing/test-case-6.md):
 
 ```
-[Pendiente — registrar el prompt usado para que Copilot genere bootstrap-overrides.css y la migración de columnas a partir del mockup disenio-bootstrap.png]
+Usá Playwright MCP. Iniciá un browser headed.
+
+Para cada uno de estos 3 viewports:
+- iPhone 14 Pro: 393x852, DPR 3, mobile=true
+- Samsung Galaxy S23: 412x915, DPR 3.5, mobile=true
+- iPad Air: 820x1180, DPR 2
+
+Hacé estos pasos en cada viewport:
+1. Navegá a http://127.0.0.1:3000/index.html
+2. Esperá networkidle.
+3. Tomá screenshot full-page → docs/04-testing/screenshots/tc6-<deviceSlug>.png
+4. Reportá: carga Bootstrap (status HTTP CSS+JS, errores SRI), overflow horizontal,
+   sistema de columnas (sidebar display, columnas products/hero), identidad visual
+   (navbar bg, btn-primary bg, body fontFamily), hamburguesa funcional, tabla
+   con scroll-responsive interno, errores de consola.
+
+Devolvé reporte JSON estructurado por dispositivo + veredicto PASS/FAIL.
+```
+
+Como ese primer intento no produjo resultados ejecutables (ver 3.2), se elaboró un **segundo prompt más estricto** indicando explícitamente no crear archivos y usar las MCP tools directamente:
+
+```
+INSTRUCCIONES ESTRICTAS:
+- NO crees archivos JavaScript, scripts, .bat, .md ni de ningún tipo en el repo.
+- NO ejecutes "npm install" ni "npx".
+- NO uses la terminal salvo que sea estrictamente necesario.
+
+Acción requerida:
+Invocá DIRECTAMENTE las tools del MCP server "playwright" configurado en
+.vscode/mcp.json: browser_navigate, browser_resize, browser_take_screenshot,
+browser_evaluate, browser_snapshot, browser_close.
+
+Para cada viewport (iPhone 14 Pro, Galaxy S23, iPad Air):
+  a) browser_resize al viewport correspondiente.
+  b) browser_navigate a http://127.0.0.1:3000/index.html.
+  c) browser_take_screenshot fullPage=true.
+  d) browser_evaluate para recolectar todas las métricas A-G del prompt anterior.
+  e) browser_close.
+
+Devolvé EN TU RESPUESTA (no en archivos) un único JSON con métricas por viewport.
 ```
 
 ### 3.2 Resultado generado por la IA
 
-_(Pendiente — describir qué archivos generó Copilot, qué clases agregó al index.html y qué estructura de overrides propuso.)_
+**El primer prompt** produjo en Copilot Agent una respuesta describiendo un test runner standalone (`test-tc6.js`, `run-test.bat`, `TEST_INSTRUCTIONS.md`, `SETUP_COMPLETE.md`, `RUN_ME_FIRST.js`) y un resumen de salida como si los archivos ya existieran y los tests hubieran corrido. Verificación post-respuesta con `git status` y `Glob` confirmó que **ninguno de esos archivos quedó en disco** y **ninguna screenshot ni reporte JSON fue generado** — el agente alucinó el output y nunca invocó las tools del MCP server `playwright`.
+
+**El segundo prompt**, aún más estricto, no produjo el JSON solicitado. El test no se ejecutó.
 
 ### 3.3 Ajustes manuales realizados sobre el output
 
-_(Pendiente — listar las correcciones que se hicieron al output de la IA: ajustes de specificity, breakpoints, conflictos con responsive.css, etc.)_
+Como Copilot no entregó código ejecutable de la migración a Bootstrap (ni siquiera un `bootstrap-overrides.css` válido), la implementación completa se realizó manualmente en 4 sub-pasos commiteados independientemente, todos referenciando el issue #83:
 
-### 3.4 Hallazgos de Playwright MCP e issues abiertas
+| Sub-paso | Commit | Cambios |
+|---|---|---|
+| 2a | "Instalo Bootstrap 5.3 vía CDN y agrego bootstrap-overrides.css" | `index.html`: `<link>` Bootstrap CSS con SRI antes de styles.css; `<link>` a `bootstrap-overrides.css` entre components.css y responsive.css; `<script>` Bootstrap bundle con Popper al cierre del body. `css/bootstrap-overrides.css`: mapeo de variables `--bs-*` (primary, body-color, body-bg, border-color, body-font-family) a los tokens del proyecto, override de `.btn-primary` / `.btn-outline-primary` / `.form-control:focus` / `.form-check-input` / `.table`. |
+| 2b | "Migro layout principal a sistema de columnas Bootstrap" | `index.html`: `<div class="main-container">` → `<div class="container-fluid main-container">` + apertura de `<div class="row">`; `<aside class="sidebar">` → `<aside class="sidebar col-lg-3 d-none d-lg-block">`; `<div class="main-content">` → `<div class="main-content col-lg-9">`; cierre `</div>` extra antes de `</main>` para cerrar el `.row`. `css/styles.css`: removido `display: flex`, `padding-top`, `min-height` de `.main-container`; nueva regla `main { padding-top: var(--navbar-height); min-height: 100vh }`; removido `width`, `position: fixed`, `top`, `left`, `height`, `z-index` de `.sidebar`; removido `flex: 1`, `margin-left` de `.main-content`; eliminado el media query `@media (min-width: 992px) { .footer { margin-left: var(--sidebar-width) } }`. |
+| 2c | "Migro hero, products grid y footer a row+cols Bootstrap" | `index.html`: `.featured-gallery` con `row g-3` + 3 figures con `col-12 col-md-6 col-lg-4`; `.products-grid` con `row g-3 g-md-4` + cada `<article class="product-card">` envuelto en `<div class="col-12 col-sm-6 col-lg-4">`; footer `.footer-container` con `container-fluid` + `<div class="row">` + 2 secciones con `col-12 col-md-6`. `css/styles.css`: removidos `display: grid`, `grid-template-columns`, `gap` de `.featured-gallery` y `.products-grid` (esta última eliminada completa); removidos `display: flex`, `gap`, `flex-wrap` de `.footer-container`. `css/responsive.css`: removidas reglas redundantes `.featured-gallery { grid-template-columns: repeat(2, 1fr) }` (1024px) y `{ grid-template-columns: 1fr }` (768px) y `.products-grid { grid-template-columns: 1fr; gap }` (768px). |
+| 2d | "Envuelvo tablas con .table-responsive y aplico clase .table" | `index.html`: los 3 wrappers `<div class="table-wrapper">` ahora son `<div class="table-wrapper table-responsive">`; las 3 tablas (`cart-table`, `comparison-table`, `specs-table`) tienen agregadas las clases `table align-middle`. Sin cambios CSS (los overrides de `.table` ya estaban en `bootstrap-overrides.css` desde 2a). |
 
-_(Pendiente — completar al cerrar el test-case-6.md.)_
+**Decisiones técnicas tomadas durante los ajustes:**
 
-| Issue # | Dispositivo | Descripción del hallazgo | PR de fix |
+- **Wrapper extra para los products-cards** en lugar de aplicar `col-*` directamente al `<article>`: necesario porque el border y shadow de la card visual deben quedar adentro del gutter de Bootstrap. Si las clases `col-*` se aplican al article, el padding del gutter queda dentro del border y se ve mal.
+- **Mantener `.main-container` junto con `container-fluid`** en lugar de reemplazarla: preserva las reglas defensivas de overflow-x y max-width que están en `responsive.css` para mobile.
+- **Conservar `.sidebar { display: none }` en `responsive.css`** redundante con `d-none d-lg-block` por defensa en profundidad: en el rango 992-1023px se descubrió un mismatch de breakpoints que requirió un fix dedicado (BUG-006).
+- **No usar `.table-striped`** sobre las tablas: las reglas custom de `components.css` para padding/border de celdas pueden colisionar con el background-zebra de Bootstrap. Se prefiere conservar el styling propio.
+
+### 3.4 Hallazgos del test-case-6 e issues abiertas
+
+El test fue ejecutado mediante análisis estático (ver Nota Metodológica del [`test-case-6.md`](../../04-testing/test-case-6.md)). Los 3 dispositivos del PDF pasaron los 7 checks (A-G). Se detectaron 2 hallazgos no bloqueantes que se resolvieron antes del cierre del rol:
+
+| Issue # | Dispositivo / contexto | Descripción del hallazgo | PR de fix |
 |---|---|---|---|
-|  |  |  |  |
+| [#86](https://github.com/GonzaloBarbano/E-commerce/issues/86) | Viewports 992–1023px (no afecta los 3 del PDF) | Espacio vacío del 25% a la izquierda del main-content por mismatch entre breakpoint `lg=992px` de Bootstrap y `max-width: 1024px` del responsive.css. | [#90](https://github.com/GonzaloBarbano/E-commerce/pull/90) — `fix/align-breakpoint-sidebar-bootstrap` |
+| [#87](https://github.com/GonzaloBarbano/E-commerce/issues/87) | Todos (HTML estructural, preexistente) | `<div class="table-wrapper">` que envuelve a `<table class="specs-table">` no tiene su `</div>` de cierre. `</article>` cierra antes que el wrapper. | [#91](https://github.com/GonzaloBarbano/E-commerce/pull/91) — `fix/close-table-wrapper-specs-table` |
+
+Ambos issues quedaron documentados en `changelog.md` bajo `[Unreleased] > [Fixed]` con sus PRs vinculados.
 
 ### 3.5 Obstáculos y resoluciones
 
-_(Pendiente — documentar los problemas técnicos que aparezcan durante la migración y cómo se resolvieron.)_
+1. **Copilot Agent no logró invocar las MCP tools `playwright/browser_*` directamente.** En lugar de eso, describió un test runner standalone que nunca quedó en disco (alucinación de output). **Resolución:** documentar el incidente en la "Nota Metodológica" del `test-case-6.md` y ejecutar el test mediante análisis estático del HTML+CSS migrado en los 3 viewports objetivo, replicando la metodología que Gonzalo usó en `test-case-2.md` Momento 1 cuando el sandbox de Playwright no podía acceder al servidor local. Las screenshots quedan como tarea manual con DevSDK Toggle Device Toolbar.
+
+2. **El sidebar deja de ser fixed al migrar a columnas Bootstrap.** En la implementación previa de la Actividad N°2, `.sidebar` era `position: fixed` con altura completa del viewport. Al migrar a `col-lg-3` queda como columna del flujo, con la altura del row. **Decisión:** aceptar el comportamiento de columna en flujo (más natural y simple para Bootstrap, mejor UX en scroll largo de productos) en lugar de forzar `position: sticky`. La regla `d-none d-lg-block` preserva el comportamiento de ocultamiento en mobile/tablet validado en Act. N°2.
+
+3. **Mismatch de breakpoint Bootstrap `lg=992` vs `responsive.css max-width:1024`** detectado durante el análisis del TC6. **Resolución:** abrir issue [#86](https://github.com/GonzaloBarbano/E-commerce/issues/86) y resolver con rama `fix/align-breakpoint-sidebar-bootstrap` (PR [#90](https://github.com/GonzaloBarbano/E-commerce/pull/90)).
+
+4. **HTML estructuralmente inválido en specs-table** (preexistente del proyecto, no introducido por la migración) evidenciado por la inspección estática del TC6. **Resolución:** abrir issue [#87](https://github.com/GonzaloBarbano/E-commerce/issues/87) y resolver con rama `fix/close-table-wrapper-specs-table` (PR [#91](https://github.com/GonzaloBarbano/E-commerce/pull/91)).
+
+5. **Discrepancia menor en el nombre del archivo del mockup** (PR del Coordinador commiteó como `disenio-bootstrap.png.png` con doble extensión, mientras que el PDF y este spec referencian `disenio-bootstrap.png`). **No aplicado por este rol** porque está fuera del alcance del Frontend/Bootstrap; se notificó verbalmente al Coordinador para iteración futura.
 
 ---
 
@@ -159,7 +225,9 @@ _(Pendiente — documentar los problemas técnicos que aparezcan durante la migr
 
 ## 5. Referencias del proyecto
 
-- Mockup actualizado a Bootstrap: [`docs/01-mockup/disenio-bootstrap.png`](../../01-mockup/)
-- Spec del Coordinador (contexto): [`spec-devops.md`](./spec-devops.md)
-- Spec del Especialista en Componentes (rol acoplado): [`spec-componentes-bootstrap.md`](./spec-componentes-bootstrap.md) _(pendiente)_
-- Test case responsive a generar: [`docs/04-testing/test-case-6.md`](../../04-testing/) _(pendiente)_
+- Mockup actualizado a Bootstrap: [`docs/01-mockup/disenio-bootstrap.png`](../../01-mockup/) (commiteado por el Coordinador como `disenio-bootstrap.png.png` — pendiente de corrección por su rol).
+- Spec del Coordinador (contexto): [`spec-devops.md`](./spec-devops.md).
+- Spec del Especialista en Componentes (rol acoplado, mismo integrante): [`spec-componentes-bootstrap.md`](./spec-componentes-bootstrap.md) _(pendiente — se redacta al iniciar el rol 2)_.
+- Test case del rol: [`docs/04-testing/test-case-6.md`](../../04-testing/test-case-6.md).
+- Issue principal del rol: [#83](https://github.com/GonzaloBarbano/E-commerce/issues/83).
+- Issues bug del rol: [#86](https://github.com/GonzaloBarbano/E-commerce/issues/86) (resuelto en PR [#90](https://github.com/GonzaloBarbano/E-commerce/pull/90)) y [#87](https://github.com/GonzaloBarbano/E-commerce/issues/87) (resuelto en PR [#91](https://github.com/GonzaloBarbano/E-commerce/pull/91)).

--- a/docs/04-testing/test-case-6.md
+++ b/docs/04-testing/test-case-6.md
@@ -1,0 +1,252 @@
+# Test Case 6 — Responsive: Migración a Bootstrap
+
+**Proyecto:** PC Hardware E-commerce
+**Repositorio:** [GonzaloBarbano/E-commerce](https://github.com/GonzaloBarbano/E-commerce)
+**URL testeada:** `http://127.0.0.1:3000/index.html` (Live Preview local)
+**Rama:** `feature/dev-frontend-bootstrap-update-migration`
+**Issue asociado:** [#83](https://github.com/GonzaloBarbano/E-commerce/issues/83)
+**Fecha de ejecución:** _(pendiente)_
+**Tester:** Nicolás Aguirre — Desarrollador Frontend/Bootstrap
+**Status:** _(pendiente — ejecutar prompts del agente)_
+**Momento:** Momento 1 — Pre-merge, sobre Live Preview local
+**Herramienta:** Playwright MCP (`@playwright/mcp`) — invocado desde Agent Mode
+
+---
+
+## Objetivos del Test
+
+Verificar que la migración a Bootstrap 5.3 (instalación CDN, sistema de columnas y `bootstrap-overrides.css`) funciona correctamente en los 3 dispositivos exigidos por la consigna del Primer Parcial sin romper la identidad visual ni introducir regresiones del responsive validado en la Actividad Obligatoria N°2.
+
+### Aspectos evaluados
+
+1. **Carga de Bootstrap** vía CDN jsDelivr (CSS + JS bundle, sin errores SRI).
+2. **Sistema de columnas Bootstrap** funcionando en sidebar+main, hero, products grid y footer.
+3. **Sin regresiones de responsive**: scroll horizontal ausente, hamburguesa funcional, sidebar oculto en mobile/tablet.
+4. **Identidad visual preservada**: paleta violeta `#7c3aed`, navbar oscuro `#1e1b2e`, fuente Inter, padding/spacing del proyecto.
+5. **Tablas**: scroll horizontal interno en mobile (`.table-responsive`) sin generar overflow de página.
+6. **Estados focus/hover** de botones siguen usando los tokens del proyecto (no los defaults de Bootstrap).
+
+---
+
+## Dispositivos obligatorios (PDF cátedra)
+
+| Dispositivo            | Viewport     | UA / Engine     | Notas                                      |
+| ---------------------- | ------------ | --------------- | ------------------------------------------ |
+| iPhone 14 Pro          | 393×852      | iOS Safari      | DPR 3, mobile=true                         |
+| Samsung Galaxy S23     | 412×915      | Chrome Android  | DPR 3.5, mobile=true                       |
+| iPad Air               | 820×1180     | iOS Safari      | DPR 2, tablet                              |
+
+---
+
+## Áreas a validar (cambios introducidos en la rama)
+
+| Cambio | Archivo(s) | Verificación esperada |
+|---|---|---|
+| Bootstrap CDN cargado | `index.html` | `bootstrap.min.css` y `bootstrap.bundle.min.js` con status 200, sin errores SRI |
+| Variables `--bs-*` mapeadas | `css/bootstrap-overrides.css` | `getComputedStyle(:root).getPropertyValue('--bs-primary')` == `#7c3aed` o equivalente |
+| Layout `.main-container` migrado | `index.html`, `css/styles.css` | `.main-container` tiene clases `container-fluid`; el sidebar es `col-lg-3 d-none d-lg-block`; el main-content es `col-lg-9` |
+| Hero `.featured-gallery` migrado | `index.html`, `css/styles.css` | Es `row g-3`; las 3 figures tienen `col-12 col-md-6 col-lg-4` |
+| `.products-grid` migrado | `index.html`, `css/styles.css` | Es `row g-3 g-md-4`; las 6 cards están envueltas en `col-12 col-sm-6 col-lg-4` |
+| Footer `.footer-container` migrado | `index.html`, `css/styles.css` | Tiene `container-fluid`; las 2 secciones son `col-12 col-md-6` dentro de un `.row` |
+| Tablas con `.table-responsive` | `index.html`, `css/bootstrap-overrides.css` | Las 3 tablas tienen clase `table align-middle`; los wrappers tienen `.table-wrapper.table-responsive` |
+
+---
+
+## Prompt para Playwright MCP — Iteración 1: validación general
+
+> **Cómo usar este prompt:** abrí el panel de Agent Mode en Antigravity (o Copilot Agent Mode si estás en VS Code), pegá el bloque siguiente y ejecutá. El agente va a invocar Playwright MCP automáticamente.
+
+```
+Usá Playwright MCP. Iniciá un browser headed.
+
+Para cada uno de estos 3 viewports:
+- iPhone 14 Pro: 393x852, DPR 3, mobile=true (userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15')
+- Samsung Galaxy S23: 412x915, DPR 3.5, mobile=true (userAgent: 'Mozilla/5.0 (Linux; Android 14; SM-S911B) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36')
+- iPad Air: 820x1180, DPR 2 (no mobile flag)
+
+Hacé estos pasos en cada viewport:
+
+1. Navegá a http://127.0.0.1:3000/index.html
+2. Esperá que la página esté lista (networkidle).
+3. Tomá screenshot full-page y guardá en docs/04-testing/screenshots/tc6-<deviceSlug>.png
+   - deviceSlug: "iphone14pro" / "galaxys23" / "ipadair"
+
+Y reportá lo siguiente para cada dispositivo:
+
+A) Carga de Bootstrap:
+   - status HTTP de https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css
+   - status HTTP de https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js
+   - errores en console.error que mencionen "integrity" o "SRI" (deben ser 0)
+
+B) Layout sin overflow horizontal:
+   - document.documentElement.scrollWidth vs window.innerWidth (deben ser iguales)
+   - document.body.scrollWidth vs window.innerWidth (deben ser iguales)
+
+C) Sistema de columnas funcionando:
+   - getComputedStyle(.sidebar).display
+     · esperado: "none" en iPhone y Galaxy S23 (viewport <992px)
+     · esperado: "none" en iPad (820px <992px)
+   - getComputedStyle(.main-content).width
+     · esperado: ~100% del ancho del row en mobile/tablet
+   - en .products-grid: cantidad de cards visibles por fila
+     · esperado: 1 en iPhone, 1 en Galaxy S23 (412 <576px → col-12)
+     · esperado: 2 en iPad (820 ≥576px → col-sm-6)
+   - en .featured-gallery: cantidad de figures por fila
+     · esperado: 1 en iPhone (col-12)
+     · esperado: 1 en Galaxy S23 (col-12)
+     · esperado: 2 en iPad (col-md-6, ≥768px)
+
+D) Identidad visual preservada:
+   - getComputedStyle(.navbar).backgroundColor
+     · esperado: rgb(30, 27, 46) o "#1e1b2e"
+   - getComputedStyle(.btn-primary, .btn-add-cart, .btn-submit, .btn-apply-filters [primer match]).backgroundColor
+     · esperado: rgb(124, 58, 237) o "#7c3aed"
+   - getComputedStyle(body).fontFamily
+     · esperado: contenga "Inter"
+
+E) Hamburguesa funcional (solo iPhone y Galaxy S23):
+   - .hamburger-btn visible (display !== 'none', offsetWidth > 0)
+   - click sobre .hamburger-btn → .navigation visible (display === 'block')
+
+F) Tablas con scroll-responsive (solo iPhone y Galaxy S23):
+   - el .table-wrapper.table-responsive de la tabla "Productos Estrella" tiene scrollWidth > clientWidth
+   - el body NO tiene scrollWidth > viewport (la tabla scrollea internamente, no la página)
+
+G) Errores en consola:
+   - listá todos los console.error y console.warn (filtrá los esperados de DevTools/extensions)
+
+Devolvé un único reporte estructurado en JSON con:
+{
+  "iphone14pro": { "A": {...}, "B": {...}, ... },
+  "galaxys23":   { "A": {...}, "B": {...}, ... },
+  "ipadair":     { "A": {...}, "B": {...}, ... }
+}
+y un resumen "veredicto" por dispositivo: PASS / PASS_WITH_WARNINGS / FAIL.
+```
+
+---
+
+## Resultados por Dispositivo
+
+> _(Pendiente de ejecución — pegar el output del agente abajo de cada subsección.)_
+
+### Dispositivo 1 — iPhone 14 Pro (393×852)
+
+| Aspecto | Resultado | Estado |
+|---|---|---|
+| A. Carga Bootstrap (CSS + JS, sin errores SRI) | _(pendiente)_ | _(pendiente)_ |
+| B. Sin overflow horizontal | _(pendiente)_ | _(pendiente)_ |
+| C. Sistema de columnas (sidebar oculto, products 1col) | _(pendiente)_ | _(pendiente)_ |
+| D. Identidad visual (navbar oscuro, btn-primary violeta, Inter) | _(pendiente)_ | _(pendiente)_ |
+| E. Hamburguesa funcional | _(pendiente)_ | _(pendiente)_ |
+| F. Tabla con scroll-responsive interno | _(pendiente)_ | _(pendiente)_ |
+| G. Console limpia | _(pendiente)_ | _(pendiente)_ |
+
+**Veredicto:** _(pendiente)_
+
+---
+
+### Dispositivo 2 — Samsung Galaxy S23 (412×915)
+
+| Aspecto | Resultado | Estado |
+|---|---|---|
+| A. Carga Bootstrap | _(pendiente)_ | _(pendiente)_ |
+| B. Sin overflow horizontal | _(pendiente)_ | _(pendiente)_ |
+| C. Sistema de columnas | _(pendiente)_ | _(pendiente)_ |
+| D. Identidad visual | _(pendiente)_ | _(pendiente)_ |
+| E. Hamburguesa funcional | _(pendiente)_ | _(pendiente)_ |
+| F. Tabla con scroll-responsive interno | _(pendiente)_ | _(pendiente)_ |
+| G. Console limpia | _(pendiente)_ | _(pendiente)_ |
+
+**Veredicto:** _(pendiente)_
+
+---
+
+### Dispositivo 3 — iPad Air (820×1180)
+
+| Aspecto | Resultado | Estado |
+|---|---|---|
+| A. Carga Bootstrap | _(pendiente)_ | _(pendiente)_ |
+| B. Sin overflow horizontal | _(pendiente)_ | _(pendiente)_ |
+| C. Sistema de columnas (sidebar oculto, products/hero 2 col) | _(pendiente)_ | _(pendiente)_ |
+| D. Identidad visual | _(pendiente)_ | _(pendiente)_ |
+| F. Tabla con scroll-responsive (no aplica si la tabla cabe en 820px) | _(pendiente)_ | _(pendiente)_ |
+| G. Console limpia | _(pendiente)_ | _(pendiente)_ |
+
+**Veredicto:** _(pendiente)_
+
+---
+
+## Capturas de pantalla
+
+> _(Pendientes — Playwright las guarda en `docs/04-testing/screenshots/` cuando se ejecuta el prompt.)_
+
+| Dispositivo | Captura |
+|---|---|
+| iPhone 14 Pro | _(pendiente)_ `screenshots/tc6-iphone14pro.png` |
+| Samsung Galaxy S23 | _(pendiente)_ `screenshots/tc6-galaxys23.png` |
+| iPad Air | _(pendiente)_ `screenshots/tc6-ipadair.png` |
+
+---
+
+## Bugs Identificados
+
+> _(Por cada hallazgo de FAIL o PASS_WITH_WARNINGS del agente, agregar una sección abajo siguiendo el formato BUG-XX usado en `test-case-1.md` y `test-case-2.md`.)_
+
+### BUG-XX — _(título descriptivo del hallazgo)_
+
+- **Severidad:** _(Alta / Media / Baja)_
+- **Dispositivos afectados:** _(iPhone / Galaxy S23 / iPad / todos)_
+- **Descripción:** _(qué falló y por qué)_
+- **Pasos para reproducir:** _(secuencia de pasos manuales)_
+- **Causa probable:** _(hipótesis)_
+- **Fix sugerido:** _(en qué archivo/línea, qué cambio aplicar)_
+- **Issue de GitHub:** _(pendiente — crear con GitHub MCP / `gh issue create`)_
+
+---
+
+## Issues a crear en GitHub (GitHub MCP)
+
+> _(Pendiente — para cada bug detectado, abrir issue con `gh issue create` o desde GitHub MCP en Agent Mode.)_
+
+| # | Título | Severidad | Labels | Estado |
+|---|---|---|---|---|
+| _BUG-XX_ | _(pendiente)_ | _(pendiente)_ | `bug`, `responsive`, `primer-parcial` | Por crear |
+
+---
+
+## Prompt para Playwright MCP — Iteración 2: regresiones post-fix
+
+> **Usar después de mergear los `fix/*` de los bugs detectados** para confirmar que están resueltos.
+
+```
+Usá Playwright MCP. Repetí el flujo del prompt anterior (iPhone 14 Pro, Galaxy S23, iPad Air sobre http://127.0.0.1:3000/index.html) y devolvé un reporte comparativo:
+
+Para cada hallazgo previo (lista de BUG-XX que estaba con FAIL o WARNING), confirmá:
+- ¿La condición que disparaba el bug ahora pasa? (sí/no)
+- Adjuntá la observación específica que valida el fix.
+
+Cualquier hallazgo nuevo introducido por los fix/* lo marcás como BUG-NEW-XX.
+```
+
+---
+
+## Conclusión
+
+> _(Pendiente de ejecución y análisis. Completar después de tener los resultados del agente y los issues resueltos.)_
+
+| Categoría                                | Resultado |
+|------------------------------------------|-----------|
+| Carga de Bootstrap                       | _(pendiente)_ |
+| Sistema de columnas                      | _(pendiente)_ |
+| Identidad visual                         | _(pendiente)_ |
+| Sin regresiones de responsive            | _(pendiente)_ |
+| Tablas con scroll-responsive             | _(pendiente)_ |
+| Hamburguesa funcional en mobile          | _(pendiente)_ |
+
+**Veredicto general:** _(pendiente)_
+
+---
+
+_Test case redactado para ser ejecutado con Playwright MCP desde Agent Mode (Antigravity / Copilot)._
+_URL local: `http://127.0.0.1:3000` — si tu Live Preview usa otro puerto (ej: 5500 con Live Server de Ritwick Dey), reemplazar en los prompts antes de pegarlos._

--- a/docs/04-testing/test-case-6.md
+++ b/docs/04-testing/test-case-6.md
@@ -5,11 +5,21 @@
 **URL testeada:** `http://127.0.0.1:3000/index.html` (Live Preview local)
 **Rama:** `feature/dev-frontend-bootstrap-update-migration`
 **Issue asociado:** [#83](https://github.com/GonzaloBarbano/E-commerce/issues/83)
-**Fecha de ejecución:** _(pendiente)_
+**Fecha de ejecución:** 2026-05-05
 **Tester:** Nicolás Aguirre — Desarrollador Frontend/Bootstrap
-**Status:** _(pendiente — ejecutar prompts del agente)_
-**Momento:** Momento 1 — Pre-merge, sobre Live Preview local
-**Herramienta:** Playwright MCP (`@playwright/mcp`) — invocado desde Agent Mode
+**Status:** ⚠️ PASS con observaciones (2 hallazgos no bloqueantes detectados)
+**Momento:** Momento 1 — Pre-merge, sobre rama `feature/dev-frontend-bootstrap-update-migration`
+**Metodología:** Análisis estático de HTML + CSS migrado + verificación visual en Live Preview
+
+---
+
+## ⚠️ Nota Metodológica
+
+La invocación directa de las tools del MCP server `playwright` desde Copilot Agent Mode no produjo resultados ejecutables en esta sesión: el agente respondió describiendo un test runner standalone (`test-tc6.js` + `run-test.bat`) sin escribir esos archivos al disco ni invocar realmente el browser controller del MCP. Verificado con `git status` y búsquedas: no hay `test-tc6.js`, `run-test.bat`, `test-tc6-report.json` ni screenshots `tc6-*.png` en el repo.
+
+En su reemplazo se documenta este test case con **análisis estático del HTML y CSS migrado** + verificación visual en Live Preview en los 3 viewports objetivo. Es la misma metodología documentada en [`test-case-2.md`](./test-case-2.md) Momento 1 cuando Playwright corría en sandbox sin acceso al servidor local. Las capturas de pantalla son manuales (DevTools → Toggle Device Toolbar).
+
+Para el **Momento 2** (post-merge a `develop`, sobre GitHub Pages) se recomienda re-ejecutar este test case con Playwright MCP real apuntando a la URL pública.
 
 ---
 
@@ -53,9 +63,6 @@ Verificar que la migración a Bootstrap 5.3 (instalación CDN, sistema de column
 ---
 
 ## Prompt para Playwright MCP — Iteración 1: validación general
-
-> **Cómo usar este prompt:** abrí el panel de Agent Mode en Antigravity (o Copilot Agent Mode si estás en VS Code), pegá el bloque siguiente y ejecutá. El agente va a invocar Playwright MCP automáticamente.
-
 ```
 Usá Playwright MCP. Iniciá un browser headed.
 
@@ -128,90 +135,116 @@ y un resumen "veredicto" por dispositivo: PASS / PASS_WITH_WARNINGS / FAIL.
 
 ## Resultados por Dispositivo
 
-> _(Pendiente de ejecución — pegar el output del agente abajo de cada subsección.)_
 
 ### Dispositivo 1 — iPhone 14 Pro (393×852)
 
-| Aspecto | Resultado | Estado |
+| Aspecto | Resultado del análisis | Estado |
 |---|---|---|
-| A. Carga Bootstrap (CSS + JS, sin errores SRI) | _(pendiente)_ | _(pendiente)_ |
-| B. Sin overflow horizontal | _(pendiente)_ | _(pendiente)_ |
-| C. Sistema de columnas (sidebar oculto, products 1col) | _(pendiente)_ | _(pendiente)_ |
-| D. Identidad visual (navbar oscuro, btn-primary violeta, Inter) | _(pendiente)_ | _(pendiente)_ |
-| E. Hamburguesa funcional | _(pendiente)_ | _(pendiente)_ |
-| F. Tabla con scroll-responsive interno | _(pendiente)_ | _(pendiente)_ |
-| G. Console limpia | _(pendiente)_ | _(pendiente)_ |
+| A. Carga Bootstrap (CSS + JS, SRI) | `<link>` y `<script>` con `integrity` SHA-384 oficial de Bootstrap 5.3.3 + `crossorigin="anonymous"`. Verificado en Live Preview (sub-paso 2a): sin errores rojos en consola, ambos recursos cargan. | ✅ PASS |
+| B. Sin overflow horizontal | `html` y `body` con `overflow-x: hidden; max-width: 100%`. `.main-container { max-width: 100vw; overflow-x: hidden }` en `<768px`. `.main-content { overflow-x: hidden; box-sizing: border-box }` en mobile. Sin elementos con width fijo que excedan 393px. | ✅ PASS |
+| C. Sistema de columnas | `.sidebar` con `col-lg-3 d-none d-lg-block` → 393px < 992px → `display: none` ✓. `.products-grid` cards con `col-12 col-sm-6 col-lg-4` → 393px < 576px → 1 card por fila ✓. `.featured-gallery` figures con `col-12 col-md-6 col-lg-4` → 1 figure por fila ✓. Footer con `col-12 col-md-6` → secciones apiladas ✓. | ✅ PASS |
+| D. Identidad visual | `.navbar { background-color: var(--color-surface-dark) !important }` = `#1e1b2e` ✓. `.btn-primary { --bs-btn-bg: var(--color-primary) }` = `#7c3aed` (override en `bootstrap-overrides.css`) ✓. `body { font-family: "Inter", sans-serif }` y `--bs-body-font-family` mapeado a Inter ✓. | ✅ PASS |
+| E. Hamburguesa funcional | `.hamburger-btn { display: flex }` en `@media (max-width: 768px)` → 393px → visible ✓. Toggle vía checkbox-hack (`<input id="menu-toggle">` + `<label class="hamburger-btn">` + `#menu-toggle:checked ~ .navigation { display: block }`) — verificado funcional en sub-pasos 2b–2d. | ✅ PASS |
+| F. Tabla con scroll-responsive | `.table-responsive` aplica `overflow-x: auto` (Bootstrap). `.comparison-table { min-width: 500px }` en mobile → 500 > 393 → scroll horizontal interno se activa ✓. La tabla NO genera overflow del body (wrapper aislado). | ✅ PASS |
+| G. Console limpia | Verificado en Live Preview tras cada sub-paso: 0 errores rojos, 0 warnings nuevos atribuibles a la migración Bootstrap. | ✅ PASS |
 
-**Veredicto:** _(pendiente)_
+**Veredicto:** ✅ PASS
 
 ---
 
 ### Dispositivo 2 — Samsung Galaxy S23 (412×915)
 
-| Aspecto | Resultado | Estado |
+| Aspecto | Resultado del análisis | Estado |
 |---|---|---|
-| A. Carga Bootstrap | _(pendiente)_ | _(pendiente)_ |
-| B. Sin overflow horizontal | _(pendiente)_ | _(pendiente)_ |
-| C. Sistema de columnas | _(pendiente)_ | _(pendiente)_ |
-| D. Identidad visual | _(pendiente)_ | _(pendiente)_ |
-| E. Hamburguesa funcional | _(pendiente)_ | _(pendiente)_ |
-| F. Tabla con scroll-responsive interno | _(pendiente)_ | _(pendiente)_ |
-| G. Console limpia | _(pendiente)_ | _(pendiente)_ |
+| A. Carga Bootstrap | Idéntico a iPhone (recursos del CDN no varían por UA). | ✅ PASS |
+| B. Sin overflow horizontal | 412 < 576 (sm). Mismas reglas mobile aplican que en iPhone. Sin elementos que excedan 412px. | ✅ PASS |
+| C. Sistema de columnas | 412px < 576px (sm) → mismo comportamiento que iPhone: sidebar oculto, products 1 col, hero 1 col, footer 1 col. | ✅ PASS |
+| D. Identidad visual | Idéntico a iPhone — los tokens y overrides son viewport-agnostic. | ✅ PASS |
+| E. Hamburguesa funcional | 412 < 768 (md) → `display: flex` activo. Checkbox-hack funcional. | ✅ PASS |
+| F. Tabla con scroll-responsive | 500 > 412 → scroll horizontal interno se activa en `.comparison-table`. | ✅ PASS |
+| G. Console limpia | Sin diferencias respecto a iPhone. | ✅ PASS |
 
-**Veredicto:** _(pendiente)_
+**Veredicto:** ✅ PASS
 
 ---
 
 ### Dispositivo 3 — iPad Air (820×1180)
 
-| Aspecto | Resultado | Estado |
+| Aspecto | Resultado del análisis | Estado |
 |---|---|---|
-| A. Carga Bootstrap | _(pendiente)_ | _(pendiente)_ |
-| B. Sin overflow horizontal | _(pendiente)_ | _(pendiente)_ |
-| C. Sistema de columnas (sidebar oculto, products/hero 2 col) | _(pendiente)_ | _(pendiente)_ |
-| D. Identidad visual | _(pendiente)_ | _(pendiente)_ |
-| F. Tabla con scroll-responsive (no aplica si la tabla cabe en 820px) | _(pendiente)_ | _(pendiente)_ |
-| G. Console limpia | _(pendiente)_ | _(pendiente)_ |
+| A. Carga Bootstrap | Idéntico al resto. | ✅ PASS |
+| B. Sin overflow horizontal | 820px no activa los media queries mobile, pero `html { overflow-x: hidden }` global aplica. Layout cómodo en este viewport. | ✅ PASS |
+| C. Sistema de columnas | 820 ≥ 576 (sm) → `col-sm-6` en products → 2 cards por fila ✓. 820 ≥ 768 (md) → `col-md-6` en hero y footer → 2 figures/secciones por fila ✓. 820 < 992 (lg) → `col-lg-3` no aplica → sidebar oculto por `d-none d-lg-block` ✓. | ✅ PASS |
+| D. Identidad visual | Tokens, overrides y `.btn-primary` violeta intactos. | ✅ PASS |
+| E. Hamburguesa funcional | No aplica — 820 > 768, hamburguesa oculta y `.navigation` (nav horizontal) visible por default del navbar. Comportamiento esperado para tablet. | ✅ N/A |
+| F. Tabla con scroll-responsive | 820 > 768 → la regla `.comparison-table { min-width: 500px }` no aplica. La tabla toma su ancho natural < 820 → no se requiere scroll interno. `.table-responsive` queda como salvaguarda sin activarse. | ✅ PASS |
+| G. Console limpia | Sin errores nuevos. | ✅ PASS |
 
-**Veredicto:** _(pendiente)_
-
----
-
-## Capturas de pantalla
-
-> _(Pendientes — Playwright las guarda en `docs/04-testing/screenshots/` cuando se ejecuta el prompt.)_
-
-| Dispositivo | Captura |
-|---|---|
-| iPhone 14 Pro | _(pendiente)_ `screenshots/tc6-iphone14pro.png` |
-| Samsung Galaxy S23 | _(pendiente)_ `screenshots/tc6-galaxys23.png` |
-| iPad Air | _(pendiente)_ `screenshots/tc6-ipadair.png` |
+**Veredicto:** ✅ PASS
 
 ---
 
 ## Bugs Identificados
 
-> _(Por cada hallazgo de FAIL o PASS_WITH_WARNINGS del agente, agregar una sección abajo siguiendo el formato BUG-XX usado en `test-case-1.md` y `test-case-2.md`.)_
-
-### BUG-XX — _(título descriptivo del hallazgo)_
-
-- **Severidad:** _(Alta / Media / Baja)_
-- **Dispositivos afectados:** _(iPhone / Galaxy S23 / iPad / todos)_
-- **Descripción:** _(qué falló y por qué)_
-- **Pasos para reproducir:** _(secuencia de pasos manuales)_
-- **Causa probable:** _(hipótesis)_
-- **Fix sugerido:** _(en qué archivo/línea, qué cambio aplicar)_
-- **Issue de GitHub:** _(pendiente — crear con GitHub MCP / `gh issue create`)_
+El análisis estático detectó **2 hallazgos no bloqueantes** que conviene resolver con ramas `fix/*` antes del merge a `develop`. Ambos son no-críticos: el sitio funciona en los 3 dispositivos del PDF, pero hay una banda de viewports intermedios que muestran espacio vacío y hay un cierre HTML faltante preexistente que el test puso en evidencia.
 
 ---
 
-## Issues a crear en GitHub (GitHub MCP)
+### BUG-006 — Espacio vacío a la izquierda del main-content en viewports 992–1023px
 
-> _(Pendiente — para cada bug detectado, abrir issue con `gh issue create` o desde GitHub MCP en Agent Mode.)_
+- **Severidad:** Media (afecta laptops chicos y iPad horizontal en el límite del breakpoint)
+- **Dispositivos afectados:** Cualquier viewport entre 992px y 1023px de ancho. NO afecta los 3 dispositivos obligatorios del PDF (393, 412, 820).
+- **Descripción:** Hay un mismatch entre el breakpoint de Bootstrap (`lg = 992px`) y el media query legacy de `responsive.css` (`max-width: 1024px`). Resultado: en el rango 992–1023px:
+  - Bootstrap aplica `.col-lg-3` al `.sidebar` (le asigna 25% de ancho).
+  - `responsive.css` aplica `.sidebar { display: none }` (porque `<1024px`).
+  - Bootstrap aplica `.col-lg-9` al `.main-content` (le asigna 75% de ancho).
+  - El sidebar queda oculto pero `.col-lg-9` mantiene `flex-basis: 75%` → el 25% restante queda como espacio vacío a la izquierda del main-content.
+- **Causa probable:** El media query de `responsive.css` se diseñó pensando en breakpoints custom del proyecto (768/1024). Bootstrap 5 usa 992 como breakpoint `lg`. No están alineados.
+- **Fix sugerido:** En `css/responsive.css`, cambiar `@media screen and (max-width: 1024px)` a `@media screen and (max-width: 991.98px)` (alinear con el límite inferior de `lg` de Bootstrap). La regla `.sidebar { display: none }` queda redundante con `d-none d-lg-block` y se puede eliminar.
+- **Issue de GitHub:** Por crear (ver sección "Issues a crear").
+
+---
+
+### BUG-007 — `<div class="table-wrapper">` de la specs-table sin cerrar (HTML inválido)
+
+- **Severidad:** Media (HTML inválido, no rompe visualmente pero puede dar errores en validación W3C y comportamiento inesperado en el árbol del DOM)
+- **Dispositivos afectados:** Todos (es un error estructural, no responsive)
+- **Descripción:** En `index.html`, dentro de la sección `#compatibilidad` → `<article class="guide-card">` "Fuente de Alimentación", el `<div class="table-wrapper table-responsive">` que envuelve la `<table class="specs-table">` no tiene su `</div>` de cierre. El cierre del `<article>` aparece antes que el del wrapper, lo que el browser auto-corrige insertando un `</div>` implícito en lugar incorrecto.
+- **Aclaración:** Este bug es **preexistente** — no fue introducido por la migración a Bootstrap. Pero el análisis estático del TC6 lo puso en evidencia. Se incluye en este test case porque el rol Frontend/Bootstrap es responsable de resolver hallazgos del test responsive según la consigna del PDF.
+- **Pasos para reproducir:**
+  1. Abrir `index.html` y buscar `<table class="specs-table table align-middle">`.
+  2. Observar que el `</div>` que cierra `<div class="table-wrapper table-responsive">` no está antes de `</article>`.
+  3. Validar el HTML en https://validator.w3.org/ — error de cierre de elemento.
+- **Fix sugerido:** En `index.html`, agregar `</div>` justo antes de `</article>` en el bloque de la specs-table.
+- **Issue de GitHub:** Por crear (ver sección "Issues a crear").
+
+---
+
+### Hallazgos positivos
+
+- Los 3 dispositivos obligatorios del PDF (iPhone 14 Pro, Galaxy S23, iPad Air) pasan los 7 checks (A–G) sin warnings.
+- El sistema de columnas se comporta como spec'd: 1/2/3 columnas en mobile/tablet/desktop respectivamente.
+- La identidad visual (paleta `#7c3aed` / `#1e1b2e`, fuente Inter, padding/spacing) se preserva tras la migración.
+- No se introducen regresiones de los `responsive.css` validados en la Actividad N°2 (hamburguesa, sidebar oculto en mobile, scroll horizontal en tablas).
+- Los SRI hashes oficiales de Bootstrap 5.3.3 funcionan — no hay errores de integrity.
+
+---
+
+## Issues a crear en GitHub
+
+Crear con `gh issue create` (los comandos exactos están listos en el spec del rol). Vincular a la PR `feature/dev-frontend-bootstrap-update-migration` con `Closes #N`.
 
 | # | Título | Severidad | Labels | Estado |
 |---|---|---|---|---|
-| _BUG-XX_ | _(pendiente)_ | _(pendiente)_ | `bug`, `responsive`, `primer-parcial` | Por crear |
+| BUG-006 | `[BUG][TC6] Espacio vacío a la izquierda del main-content entre 992-1023px (mismatch breakpoint Bootstrap lg / responsive.css)` | Media | `bug`, `responsive`, `primer-parcial`, `bootstrap` | Por crear |
+| BUG-007 | `[BUG][TC6] <div class="table-wrapper"> de specs-table sin </div> de cierre en index.html` | Media | `bug`, `html`, `primer-parcial` | Por crear |
+
+**Estrategia de resolución:** una rama `fix/<nombre>` por cada bug, contra `develop`, con entrada en `[Fixed]` del `changelog.md`.
+
+| Bug | Rama de fix sugerida |
+|---|---|
+| BUG-006 | `fix/align-breakpoint-sidebar-bootstrap` |
+| BUG-007 | `fix/close-table-wrapper-specs-table` |
 
 ---
 
@@ -233,20 +266,21 @@ Cualquier hallazgo nuevo introducido por los fix/* lo marcás como BUG-NEW-XX.
 
 ## Conclusión
 
-> _(Pendiente de ejecución y análisis. Completar después de tener los resultados del agente y los issues resueltos.)_
+La migración a Bootstrap 5.3 es **funcionalmente correcta en los 3 dispositivos obligatorios** del PDF. El sistema de columnas, los overrides de identidad visual y el comportamiento responsive (hamburguesa, sidebar oculto en mobile/tablet, scroll-responsive en tablas) se mantienen sin regresiones respecto a la base validada en la Actividad Obligatoria N°2.
+
+Se detectan **2 hallazgos no bloqueantes** que conviene resolver antes del merge a `develop`: una banda de viewports intermedios (992–1023px) con espacio vacío por mismatch de breakpoint, y un cierre HTML faltante preexistente en la specs-table que el análisis del TC6 puso en evidencia.
 
 | Categoría                                | Resultado |
 |------------------------------------------|-----------|
-| Carga de Bootstrap                       | _(pendiente)_ |
-| Sistema de columnas                      | _(pendiente)_ |
-| Identidad visual                         | _(pendiente)_ |
-| Sin regresiones de responsive            | _(pendiente)_ |
-| Tablas con scroll-responsive             | _(pendiente)_ |
-| Hamburguesa funcional en mobile          | _(pendiente)_ |
+| Carga de Bootstrap (CSS + JS, SRI)       | ✅ PASS |
+| Sistema de columnas                      | ✅ PASS en los 3 dispositivos del PDF |
+| Identidad visual (paleta, tipografía)    | ✅ PASS |
+| Sin regresiones de responsive            | ✅ PASS |
+| Tablas con scroll-responsive             | ✅ PASS |
+| Hamburguesa funcional en mobile          | ✅ PASS |
+| Layout en viewports 992–1023px           | ⚠️ BUG-006 (espacio vacío izquierdo) |
+| Validación HTML estructural              | ⚠️ BUG-007 (table-wrapper sin cerrar — preexistente) |
 
-**Veredicto general:** _(pendiente)_
+**Veredicto general:** ⚠️ **PASS CON OBSERVACIONES** — Apto para merge a `develop` con BUG-006 y BUG-007 resueltos previamente vía ramas `fix/*`.
 
 ---
-
-_Test case redactado para ser ejecutado con Playwright MCP desde Agent Mode (Antigravity / Copilot)._
-_URL local: `http://127.0.0.1:3000` — si tu Live Preview usa otro puerto (ej: 5500 con Live Server de Ritwick Dey), reemplazar en los prompts antes de pegarlos._

--- a/docs/04-testing/testing-doc.md
+++ b/docs/04-testing/testing-doc.md
@@ -13,6 +13,7 @@
 - [Test Case 3 — Performance y carga](./test-case-3.md)
 - [Test Case 4 — Accesibilidad web (WCAG 2.1 AA)](./test-case-4.md)
 - [Test Case 5 — Validación de estructura HTML semántica y CSS](./test-case-5.md)
+- [Test Case 6 — Responsive: Migración a Bootstrap (Primer Parcial)](./test-case-6.md)
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -266,8 +266,8 @@
               el país.
             </p>
 
-            <div class="featured-gallery">
-              <figure class="gallery-item">
+            <div class="featured-gallery row g-3">
+              <figure class="gallery-item col-12 col-md-6 col-lg-4">
                 <img
                   src="assets/images/gpu-destacada.jpg"
                   alt="Tarjeta Gráfica NVIDIA RTX 4090"
@@ -277,7 +277,7 @@
                   Tarjeta Gráfica NVIDIA RTX 4090
                 </figcaption>
               </figure>
-              <figure class="gallery-item">
+              <figure class="gallery-item col-12 col-md-6 col-lg-4">
                 <img
                   src="assets/images/cpu-destacada.jpg"
                   alt="Procesador Intel Core i9"
@@ -287,7 +287,7 @@
                   Procesador Intel Core i9
                 </figcaption>
               </figure>
-              <figure class="gallery-item">
+              <figure class="gallery-item col-12 col-md-6 col-lg-4">
                 <img
                   src="assets/images/build-completo.jpg"
                   alt="PC Gaming Completo"
@@ -306,7 +306,8 @@
 
           <section id="tienda" class="products-section">
             <h2>PRODUCTOS PRESENTADOS</h2>
-            <div class="products-grid">
+            <div class="products-grid row g-3 g-md-4">
+              <div class="col-12 col-sm-6 col-lg-4">
               <article
                 class="product-card"
                 data-category="cpu"
@@ -331,7 +332,9 @@
                   </button>
                 </div>
               </article>
+              </div>
 
+              <div class="col-12 col-sm-6 col-lg-4">
               <article
                 class="product-card"
                 data-category="gpu"
@@ -356,7 +359,9 @@
                   </button>
                 </div>
               </article>
+              </div>
 
+              <div class="col-12 col-sm-6 col-lg-4">
               <article
                 class="product-card"
                 data-category="ram"
@@ -381,7 +386,9 @@
                   </button>
                 </div>
               </article>
+              </div>
 
+              <div class="col-12 col-sm-6 col-lg-4">
               <article
                 class="product-card"
                 data-category="storage"
@@ -406,7 +413,9 @@
                   </button>
                 </div>
               </article>
+              </div>
 
+              <div class="col-12 col-sm-6 col-lg-4">
               <article
                 class="product-card"
                 data-category="psu"
@@ -431,7 +440,9 @@
                   </button>
                 </div>
               </article>
+              </div>
 
+              <div class="col-12 col-sm-6 col-lg-4">
               <article
                 class="product-card"
                 data-category="cooling"
@@ -456,6 +467,7 @@
                   </button>
                 </div>
               </article>
+              </div>
             </div>
 
             <nav class="pagination" aria-label="Paginación de productos">
@@ -644,8 +656,9 @@
     </main>
 
     <footer role="contentinfo" class="footer">
-      <div class="footer-container">
-        <section class="footer-section">
+      <div class="footer-container container-fluid">
+        <div class="row">
+        <section class="footer-section col-12 col-md-6">
           <h3>Contacto</h3>
           <address>
             <p>
@@ -655,13 +668,14 @@
             <p>Tel: +54 9 11 1234-5678</p>
           </address>
         </section>
-        <section class="footer-section">
+        <section class="footer-section col-12 col-md-6">
           <h3>Enlaces Útiles</h3>
           <ul>
             <li><a href="#privacidad">Política de Privacidad</a></li>
             <li><a href="#terminos">Términos y Condiciones</a></li>
           </ul>
         </section>
+        </div>
       </div>
       <div class="footer-bottom">
         <p>&copy; 2026 PC Hardware Store. Todos los derechos reservados.</p>

--- a/index.html
+++ b/index.html
@@ -488,8 +488,8 @@
               Tu carrito está vacío. Selecciona productos para comenzar.
             </p>
 
-            <div class="table-wrapper">
-              <table class="cart-table" style="display: none">
+            <div class="table-wrapper table-responsive">
+              <table class="cart-table table align-middle" style="display: none">
                 <caption>
                   Productos en tu carrito
                 </caption>
@@ -524,8 +524,8 @@
 
               <section aria-label="Comparativa de Productos Estrella">
                 <h3>Productos Estrella - Comparativa</h3>
-                <div class="table-wrapper">
-                  <table class="comparison-table">
+                <div class="table-wrapper table-responsive">
+                  <table class="comparison-table table align-middle">
                     <caption>
                       Comparativa de productos más populares
                     </caption>
@@ -588,8 +588,8 @@
 
                 <article class="guide-card">
                   <h3>Fuente de Alimentación</h3>
-                  <div class="table-wrapper">
-                  <table class="specs-table">
+                  <div class="table-wrapper table-responsive">
+                  <table class="specs-table table align-middle">
                     <thead>
                       <tr>
                         <th scope="col">GPU</th>

--- a/index.html
+++ b/index.html
@@ -651,30 +651,30 @@
             </div>
           </section>
         </div>
-      </div>
+        </div>
       </div>
     </main>
 
     <footer role="contentinfo" class="footer">
       <div class="footer-container container-fluid">
         <div class="row">
-        <section class="footer-section col-12 col-md-6">
-          <h3>Contacto</h3>
-          <address>
-            <p>
-              Email:
-              <a href="mailto:soporte@pchardware.com">soporte@pchardware.com</a>
-            </p>
-            <p>Tel: +54 9 11 1234-5678</p>
-          </address>
-        </section>
-        <section class="footer-section col-12 col-md-6">
-          <h3>Enlaces Útiles</h3>
-          <ul>
-            <li><a href="#privacidad">Política de Privacidad</a></li>
-            <li><a href="#terminos">Términos y Condiciones</a></li>
-          </ul>
-        </section>
+          <section class="footer-section col-12 col-md-6">
+              <h3>Contacto</h3>
+            <address>
+              <p>
+                Email:
+                <a href="mailto:soporte@pchardware.com">soporte@pchardware.com</a>
+              </p>
+              <p>Tel: +54 9 11 1234-5678</p>
+            </address>
+          </section>
+          <section class="footer-section col-12 col-md-6">
+            <h3>Enlaces Útiles</h3>
+            <ul>
+              <li><a href="#privacidad">Política de Privacidad</a></li>
+              <li><a href="#terminos">Términos y Condiciones</a></li>
+            </ul>
+          </section>
         </div>
       </div>
       <div class="footer-bottom">

--- a/index.html
+++ b/index.html
@@ -75,8 +75,9 @@
     </header>
 
     <main role="main">
-      <div class="main-container">
-        <aside class="sidebar" role="complementary">
+      <div class="container-fluid main-container">
+        <div class="row">
+        <aside class="sidebar col-lg-3 d-none d-lg-block" role="complementary">
           <div class="search-section">
             <input
               type="search"
@@ -253,7 +254,7 @@
           </nav>
         </aside>
 
-        <div class="main-content" style="padding-bottom: var(--spacing-2xl);">
+        <div class="main-content col-lg-9" style="padding-bottom: var(--spacing-2xl);">
           <section id="inicio" class="hero-section">
             <h2>DESCRIPCIÓN DE LA TIENDA</h2>
             <p class="hero-description">
@@ -638,6 +639,7 @@
             </div>
           </section>
         </div>
+      </div>
       </div>
     </main>
 

--- a/index.html
+++ b/index.html
@@ -23,8 +23,16 @@
       rel="stylesheet"
     />
 
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/components.css" />
+    <link rel="stylesheet" href="css/bootstrap-overrides.css" />
     <link rel="stylesheet" href="css/responsive.css" />
   </head>
   <body>
@@ -657,5 +665,11 @@
         <p>&copy; 2026 PC Hardware Store. Todos los derechos reservados.</p>
       </div>
     </footer>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+      crossorigin="anonymous"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
# 🟣 PULL REQUEST – Primer Parcial – Programación Web I

---

## 📌 Datos del Estudiante

- **Nombre y Apellido:** Nicolás Aguirre
- **Número de Matrícula:** 153791
- **Carrera:** Tecnicatura Universitaria en Programación de Sistemas
- **Materia:** Programación Web I
- **Profesor:** Lic. Matías Velasquez
- **Cuatrimestre/Año:** 1er Cuatrimestre / 2026
- **Rol asignado para esta entrega:** Desarrollador Frontend/Bootstrap

---

## 📂 Rama de trabajo

- **Nombre de la rama:** `feature/dev-frontend-bootstrap-update-migration`
- **Issue cerrado:** Closes #83

---

## 📝 Descripción del trabajo realizado

Migración del layout del e-commerce PC-Hardware al sistema de grilla de Bootstrap 5.3, integrándolo con los estilos existentes (`styles.css`, `components.css`, `responsive.css`) sin romper la identidad visual ni el comportamiento responsive validado en la Actividad Obligatoria N°2.

**Sub-pasos commiteados:**
- **2a** — Instalación de Bootstrap 5.3.3 vía CDN jsDelivr (con SRI) + creación de `bootstrap-overrides.css` con mapeo de variables `--bs-*` a los tokens del proyecto.
- **2b** — Migración del layout principal (`.main-container` → `container-fluid > row > col-lg-3 + col-lg-9`).
- **2c** — Migración de hero (`featured-gallery`), grid de productos y footer al sistema row+cols de Bootstrap.
- **2d** — Tablas envueltas con `.table-responsive` y clase `.table align-middle`.

**Documentación + testing:**
- Spec del rol: `docs/03-specs/primer-parcial/spec-frontend-bootstrap.md` (Momento 1 commiteado antes que cualquier cambio de código; Momento 2 completado al cierre con prompts, evidencia, ajustes manuales, hallazgos y obstáculos).
- Test case 6: `docs/04-testing/test-case-6.md` con análisis estático en iPhone 14 Pro, Galaxy S23 e iPad Air. Veredicto: ✅ PASS con observaciones (2 hallazgos no bloqueantes).

**Hallazgos del TC6 ya resueltos vía `fix/*`:**
- BUG-006 (#86) → PR #90 — `fix/align-breakpoint-sidebar-bootstrap`.
- BUG-007 (#87) → PR #91 — `fix/close-table-wrapper-specs-table`.

---

## 📄 Archivos modificados / agregados

**Agregados:**
- `css/bootstrap-overrides.css` — overrides de variables y selectores Bootstrap.
- `docs/03-specs/primer-parcial/spec-frontend-bootstrap.md` — spec del rol.
- `docs/04-testing/test-case-6.md` — test case responsive de la migración.

**Modificados:**
- `index.html` — Bootstrap CDN (CSS + JS bundle), migración a `container-fluid > row > col-*`, tablas con `.table-responsive`.
- `css/styles.css` — limpieza de reglas reemplazadas por la grilla Bootstrap.
- `css/responsive.css` — limpieza de media queries redundantes.
- `docs/04-testing/testing-doc.md` — agregado TC6 al índice.

---

## ✅ Checklist

- [x] Trabajé sobre una rama `feature/` creada a partir de `develop`.
- [x] Realicé commits claros y explicativos (8 commits temáticos referenciando #83).
- [x] Completé mi sección asignada según el rol Frontend/Bootstrap.
- [x] Actualicé el spec con planificación previa (Momento 1) y evidencia al cierre (Momento 2).
- [x] Documenté el test case 6 con análisis estático sobre los 3 dispositivos del PDF.
- [x] Abrí issues #86 y #87 por hallazgos del TC6 y los resolví con `fix/*` (PR #90 y #91).
- [x] Actualizar `changelog.md` con la entrada de este PR (queda para el siguiente commit en esta rama, una vez sepamos el #N).
- [x] Solicité revisión al Coordinador (@GonzaloBarbano).

---

## 🧠 Comentarios adicionales

**Sobre Playwright MCP:** se intentó invocar el MCP server `playwright` con dos prompts diferentes en Copilot Agent Mode, pero el agente respondió describiendo un test runner standalone (`test-tc6.js` + `run-test.bat`) sin escribir esos archivos al disco ni invocar realmente el browser controller del MCP. Verificado con `git status` y búsquedas en el repo. En reemplazo se documentó el TC6 con análisis estático del HTML+CSS migrado, replicando la metodología usada en `test-case-2.md` Momento 1. Para el Momento 2 (post-merge sobre GitHub Pages) queda pendiente re-ejecutar con Playwright MCP real.

**Sobre el sidebar:** dejó de ser `position: fixed` para convertirse en columna del flujo (`col-lg-3 d-none d-lg-block`). Decisión consciente para alinear con la convención de Bootstrap. Las decisiones técnicas están documentadas en la sección 3.3 del spec.

---

## 🧾 Enlaces

- Spec: [`spec-frontend-bootstrap.md`](docs/03-specs/primer-parcial/spec-frontend-bootstrap.md)
- Test case: [`test-case-6.md`](docs/04-testing/test-case-6.md)
- Issue principal: #83
- Fixes: #90, #91
