### PR TITLE
[fix] Elimino 3 lineas duplicadas en index.html del merge del PR #93

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/clean-merge-pr93] Elimino 3 líneas duplicadas en index.html introducidas por la resolución incorrecta de conflictos durante el merge del PR #93 (aperturas viejas de `.main-container`, `.sidebar` y `.products-grid` sin clases Bootstrap)
+  PR: [#PENDIENTE](https://github.com/GonzaloBarbano/E-commerce/pulls) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
+
 - [fix/close-table-wrapper-specs-table] Cierro &lt;div class="table-wrapper"&gt; faltante en la specs-table de la sección Compatibilidad — resuelve HTML inválido detectado en el TC6 (closes #87)
   PR: [#91](https://github.com/GonzaloBarbano/E-commerce/pull/91) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 
 - [fix/clean-merge-pr93] Elimino 3 líneas duplicadas en index.html introducidas por la resolución incorrecta de conflictos durante el merge del PR #93 (aperturas viejas de `.main-container`, `.sidebar` y `.products-grid` sin clases Bootstrap)
-  PR: [#PENDIENTE](https://github.com/GonzaloBarbano/E-commerce/pulls) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
+  PR: [#95](https://github.com/GonzaloBarbano/E-commerce/pull/95) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)
 
 - [fix/close-table-wrapper-specs-table] Cierro &lt;div class="table-wrapper"&gt; faltante en la specs-table de la sección Compatibilidad — resuelve HTML inválido detectado en el TC6 (closes #87)
   PR: [#91](https://github.com/GonzaloBarbano/E-commerce/pull/91) - @Naguirre0102 (Desarrollador Frontend/Bootstrap)

--- a/index.html
+++ b/index.html
@@ -78,8 +78,6 @@
       <div class="container-fluid main-container">
         <div class="row">
         <aside class="sidebar col-lg-3 d-none d-lg-block" role="complementary">
-      <div class="main-container">
-        <aside class="sidebar" role="complementary">
 
           <!-- COMPONENTE HTML AVANZADO 2 (Parte A): datalist en buscador -->
           <div class="search-section">
@@ -341,7 +339,6 @@
             <h2>PRODUCTOS PRESENTADOS</h2>
             <div class="products-grid row g-3 g-md-4">
               <div class="col-12 col-sm-6 col-lg-4">
-            <div class="products-grid">
 
               <!-- Producto 1: Intel Core i9-13900K -->
               <article


### PR DESCRIPTION
## Resumen
Elimina 3 líneas duplicadas en `index.html` que quedaron tras la resolución incorrecta de conflictos durante el merge del PR #93 a `develop`. Las aperturas viejas de `.main-container`, `.sidebar` y `.products-grid` (sin clases Bootstrap) quedaron contiguas a las versiones nuevas correctas.

## Issue cerrado
Closes #94 

## Cambios

### `index.html` — líneas eliminadas
- Línea 81: `<div class="main-container">` (versión vieja, sin `container-fluid`)
- Línea 82: `<aside class="sidebar" role="complementary">` (versión vieja, sin `col-lg-3 d-none d-lg-block`)
- Línea 344: `<div class="products-grid">` (versión vieja, sin `row g-3 g-md-4`)

### `changelog.md`
Entrada en `[Recuperatorio Parcial 1] > [Fixed]`.

## Lo que NO toca este PR
- Las cards de productos: ya quedaron bien combinadas en el merge (mi `<div class="col-*">` envolviendo los `<article>` de Lucas con `<details>`).
- El sidebar internals (datalist, range slider de Lucas): preservados intactos dentro del aside Bootstrap.
- El footer, navbar, tablas: limpios.

## Test plan
- [x] Validar que el HTML pasa validación estructural local (apertura/cierre balanceados).
- [x] Verificar visualmente en Live Preview que la página renderiza correctamente (un solo sidebar visible en desktop, un solo grid de productos).
- [ ] Confirmar con W3C validator post-merge.

## Rama
`fix/clean-merge-pr93` → `develop`
