### PR TITLE
igualar altura de tarjetas

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/test-case] Correccion product card.
+  PR: [#103](https://github.com/GonzaloBarbano/E-commerce/pull/103) - @LucasFUces (Desarrollador de Componentes HTML Avanzados)
+
 - [fix/test-case] Correccion de test-case 6 al 10, testing-doc.md y Range en index.html
   PR: [#100](https://github.com/GonzaloBarbano/E-commerce/pull/100) - @GonzaloBarbano (Coordinador / DevOps)
 

--- a/css/components.css
+++ b/css/components.css
@@ -46,6 +46,10 @@
   /* RC-FIX: evitar que la card desborde su columna de grid */
   max-width: 100%;
   box-sizing: border-box;
+  /* RC16-FIX: igual altura entre tarjetas */
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 /* RC-FIX: Cambiado object-fit de cover a contain para no recortar las imágenes */
@@ -58,6 +62,10 @@
 
 .product-info {
   padding: var(--spacing-md);
+  /* RC16-FIX: flex para empujar botón al fondo */
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
 .product-price {
@@ -65,6 +73,16 @@
   color: var(--color-primary);
   font-weight: 700;
   margin: var(--spacing-sm) 0;
+}
+
+/* RC16-FIX: nombre con altura mínima para uniformar tarjetas */
+.product-name {
+  min-height: 2.8em;
+}
+
+/* RC16-FIX: botón siempre al fondo de la tarjeta */
+.btn-add-cart {
+  margin-top: auto;
 }
 
 /* FORMULARIOS */


### PR DESCRIPTION
## Descripción
Corrección del Request Change RC16 marcado por el docente.

## Problema
Las tarjetas de producto tenían alturas diferentes cuando el nombre o descripción del producto era más largo, empujando el contenido y rompiendo la uniformidad visual de la grilla.

> Referencia: comentario del docente → https://github.com/GonzaloBarbano/E-commerce/pull/99#discussion_r3196026264

## Solución aplicada
- `display: flex; flex-direction: column` en `.product-card` para que todas las tarjetas se estiren igual
- `display: flex; flex-direction: column; flex: 1` en `.product-info` para ocupar el espacio disponible
- `margin-top: auto` en `.btn-add-cart` para que el botón siempre quede al fondo
- `min-height: 2.8em` en `.product-name` para uniformar la altura del nombre

## Archivos modificados
- `css/components.css`