### PR TITLE
Compacto menu hamburguesa mobile y alineo nav-list

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
+- [fix/menu-mobile-compacto] Compacta el menú hamburguesa en mobile (padding del nav-link de 24px a 8px) y agrega `d-flex align-items-center h-100` al `<ul class="nav-list">` — resuelve Request Change del profesor sobre PR de release del Primer Parcial
+  PR: [#PENDIENTE](https://github.com/GonzaloBarbano/E-commerce/pulls) - @Naguirre0102 (Especialista en Componentes Bootstrap)
+
 - [fix/index-2] Fix alineado de navbar
   PR: [#105](https://github.com/GonzaloBarbano/E-commerce/pull/105) - @GonzaloBarbano (Coordinador / DevOps)
 

--- a/changelog.md
+++ b/changelog.md
@@ -25,8 +25,8 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Fixed
 
-- [fix/menu-mobile-compacto] Compacta el menú hamburguesa en mobile (padding del nav-link de 24px a 8px) y agrega `d-flex align-items-center h-100` al `<ul class="nav-list">` — resuelve Request Change del profesor sobre PR de release del Primer Parcial
-  PR: [#PENDIENTE](https://github.com/GonzaloBarbano/E-commerce/pulls) - @Naguirre0102 (Especialista en Componentes Bootstrap)
+- [fix/menu-mobile-compacto] Compacta el menú hamburguesa en mobile
+  PR: [#106](https://github.com/GonzaloBarbano/E-commerce/pull/106) - @Naguirre0102 (Especialista en Componentes Bootstrap)
 
 - [fix/index-2] Fix alineado de navbar
   PR: [#105](https://github.com/GonzaloBarbano/E-commerce/pull/105) - @GonzaloBarbano (Coordinador / DevOps)

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -37,6 +37,10 @@ html {
     left: 0;
     right: 0;
     width: 100%;
+    /* override del `height: 100%` de styles.css (regla agregada por PR #105 para
+       el navbar desktop) — en mobile el menú debe tomar la altura del contenido,
+       no estirarse al viewport completo */
+    height: auto;
     background-color: var(--color-surface-dark);
     z-index: 999;
     padding: 0;
@@ -53,11 +57,24 @@ html {
     gap: 0;
     padding: var(--spacing-md) 0;
     width: 100%;
+    /* override de `height: 100%` y `align-items: center` de styles.css (PR #105):
+       en mobile el ul toma altura natural y los items son full-width (stretch) */
+    height: auto;
+    align-items: stretch;
+  }
+
+  /* override del `height: 100%` heredado de styles.css (PR #105) que estiraba
+     cada `<li>` a una fracción del viewport (efecto "items separados") */
+  .nav-item {
+    height: auto;
   }
 
   .nav-link {
     font-size: var(--font-size-body);
-    padding: var(--spacing-lg) var(--spacing-lg);
+    /* padding compacto y override del `height: 100%` heredado de styles.css
+       (PR #105) — feedback del profesor sobre PR de release del Primer Parcial */
+    padding: var(--spacing-sm) var(--spacing-lg);
+    height: auto;
     display: block;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
     transition: var(--transition-default);

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         <span></span><span></span><span></span>
       </label>
       <nav class="navigation" id="main-nav" aria-label="Navegación Principal">
-        <ul class="nav-list">
+        <ul class="nav-list d-flex align-items-center h-100">
           <li class="nav-item">
             <a href="#inicio" class="nav-link">Inicio</a>
           </li>


### PR DESCRIPTION
## Cambios

### `index.html`
- `<ul class="nav-list">` → `<ul class="nav-list d-flex align-items-center h-100">`.

### `css/responsive.css` (dentro del `@media max-width: 768px`)
- `.navigation` → agregado `height: auto`.
- `.nav-list` → agregados `height: auto` y `align-items: stretch`.
- `.nav-item` → nueva regla con `height: auto`.
- `.nav-link` → padding cambiado a `var(--spacing-sm) var(--spacing-lg)` (8px vertical) + `height: auto`.

## Test plan
- [x] Menú hamburguesa mobile (iPhone 14 Pro, 393×852) — items compactos ~36px de alto, look dropdown estándar (verificado en Live Preview).
- [x] Navbar desktop sigue alineado correctamente (regla CSS de PR #105 sigue aplicando en ≥769px).
- [x] No se introducen regresiones en el sidebar, products-grid ni footer responsive.

## Rama
`fix/menu-mobile-compacto` → `release/primer-parcial`

## Rol
Especialista en Componentes Bootstrap — @Naguirre0102
